### PR TITLE
fix(Mobile): fixed gitignore for lib folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,7 +39,6 @@ dist/
 downloads/
 eggs/
 .eggs/
-lib/
 lib64/
 parts/
 sdist/

--- a/Mobile/.gitignore
+++ b/Mobile/.gitignore
@@ -39,7 +39,6 @@ dist/
 downloads/
 eggs/
 .eggs/
-lib/
 lib64/
 parts/
 sdist/


### PR DESCRIPTION
This PR is a fix to the setup of the .gitignore files. 