### PR TITLE
(Mobile-Dartknights): Add common errors and usecases

### DIFF
--- a/Mobile/starter_project_dark_knights/lib/core/errors/failures.dart
+++ b/Mobile/starter_project_dark_knights/lib/core/errors/failures.dart
@@ -1,0 +1,9 @@
+import 'package:equatable/equatable.dart';
+
+abstract class Failure extends Equatable {
+  Failure([List properties = const <dynamic>[]]) : super();
+
+  @override
+  // TODO: implement props
+  List<Object> get props => [];
+}

--- a/Mobile/starter_project_dark_knights/lib/core/usecases/usecase.dart
+++ b/Mobile/starter_project_dark_knights/lib/core/usecases/usecase.dart
@@ -1,0 +1,12 @@
+import 'package:dark_knights/core/errors/failures.dart';
+import 'package:dartz/dartz.dart';
+import 'package:equatable/equatable.dart';
+
+abstract class UseCase<Type, Params> {
+  Future<Either<Failure, Type>> call(Params params);
+}
+
+class NoParams extends Equatable {
+  @override
+  List<Object?> get props => throw UnimplementedError();
+}

--- a/Mobile/starter_project_dark_knights/pubspec.yaml
+++ b/Mobile/starter_project_dark_knights/pubspec.yaml
@@ -35,6 +35,8 @@ dependencies:
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.2
   flutter_svg: ^2.0.5
+  equatable: ^2.0.5
+  dartz: ^0.10.1
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
The failure and usecases we write need an abstract base implementation that they extend from. So I have created the two abstract classes for everyone to use.