### PR TITLE
feat(Backend-zsilentcoders): implementing user authentication

### DIFF
--- a/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.API/BlogApp.API.csproj
+++ b/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.API/BlogApp.API.csproj
@@ -7,6 +7,7 @@
   <ItemGroup>
     <PackageReference Include="MediatR" Version="11" />
     <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="11.1.0" />
+    <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="12.0.1" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="7.0.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
@@ -20,5 +21,8 @@
   <ItemGroup>
     <ProjectReference Include="..\BlogApp.Domain\BlogApp.Domain.csproj" />
     <ProjectReference Include="..\BlogApp.Persistence\BlogApp.Persistence.csproj" />
+    <ProjectReference Include="..\BlogApp.Identity\BlogApp.Identity.csproj" />
+    <ProjectReference Include="..\BlogApp.Application\BlogApp.Application.csproj" />
+    <ProjectReference Include="..\BlogApp.Infrastructure\BlogApp.Infrastructure.csproj" />
   </ItemGroup>
 </Project>

--- a/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.API/Controllers/AuthController.cs
+++ b/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.API/Controllers/AuthController.cs
@@ -1,0 +1,98 @@
+using Microsoft.AspNetCore.Mvc;
+using BlogApp.Application.Models.Identity;
+using BlogApp.Application.Contracts.Identity;
+using BlogApp.Application.Features.Users.CQRS.Commands;
+using BlogApp.Application.Features.Users.CQRS.Queries;
+using BlogApp.Application.Features.Users.DTOs;
+using BlogApp.Application.Features.Users.DTOs;
+using BlogApp.Application.Responses;
+using MediatR;
+using AutoMapper;
+using BlogApp.Api.Controllers;
+
+namespace BlogApp.API.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+public class AuthController : BaseController
+{
+    private readonly IAuthService _authService;
+    private readonly IMediator _mediator;
+    private readonly IMapper _mapper;
+
+    public AuthController(IAuthService authService, IMediator mediator, IMapper mapper)
+    {
+        _authService = authService;
+        _mediator = mediator;
+        _mapper = mapper;
+    }
+
+    [HttpPost]
+    [Route("Login")]
+    public async Task<ActionResult<LoginResponse>> Login([FromBody] LoginModel request)
+    {
+        var response = await _authService.Login(request);
+        return HandleResult(response);
+        
+    }
+
+    [HttpPost]
+    [Route("Register")]
+    public async Task<ActionResult<Result<RegistrationResponse>>> Register([FromBody] RegisterDto registerDto)
+    {
+        var response = await _authService.Register(_mapper.Map<RegistrationModel>(registerDto));
+        var command = new Create_UserCommand {Create_UserDto = _mapper.Map<Create_UserDto>(registerDto)};
+        if (!response.Success || response.Value == null)
+            return HandleResult(response);
+
+        command.Create_UserDto.AccountId = response.Value.UserId;
+        try
+        {
+            var userResponse = await _mediator.Send(command);
+            return HandleResult(response);
+        }
+        catch(Exception e)
+        {
+            await _authService.DeleteUser(registerDto.Email);
+            response.Success = false;
+            response.Errors.Add(e.Message);
+            return HandleResult(response);
+        }
+        
+    }
+
+    [HttpGet]
+    [Route("Confirm")]
+    public async Task<ActionResult<Result<string>>> ConfirmEmail(string token, string email)
+    {
+        var response = await _authService.ConfirmEmail(token, email);
+        return HandleResult(response);
+        
+    }
+
+    [HttpGet]
+    [Route("ForgotPassword")]
+    public async Task<ActionResult<Result<string>>> ForgotPassword(string email)
+    {
+        var response = await _authService.ForgotPassword(email);
+        return HandleResult(response);
+        
+    }
+
+    [HttpPost]
+    [Route("ResetPassword")]
+    public async Task<ActionResult<Result<string>>> ResetPassword([FromBody] ResetPasswordModel resetPasswordModel)
+    {
+        var response = await _authService.ResetPassword(resetPasswordModel);
+        return HandleResult(response);
+        
+    }
+
+    [HttpDelete]
+    [Route("Delete")]
+    public async Task<ActionResult<bool>> Delete(string email)
+    {
+        var response = await _authService.DeleteUser(email);
+        return Ok(response);  
+    }
+}

--- a/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.API/Controllers/AuthController.cs
+++ b/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.API/Controllers/AuthController.cs
@@ -62,8 +62,16 @@ public class AuthController : BaseController
     }
 
     [HttpGet]
+    [Route("ResendConfirmLink")]
+    public async Task<ActionResult<Result<string>>> ResendConfirmEmailLink(string email)
+    {
+        var response = await _authService.sendConfirmEmailLink(email);
+        return HandleResult(response);
+    }
+
+    [HttpGet]
     [Route("Confirm")]
-    public async Task<ActionResult<Result<string>>> ConfirmEmail(string token, string email)
+    public async Task<ActionResult<Result<string>>> ConfirmEmail(string email, string token)
     {
         var response = await _authService.ConfirmEmail(token, email);
         return HandleResult(response);

--- a/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.API/Controllers/UserController.cs
+++ b/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.API/Controllers/UserController.cs
@@ -1,0 +1,61 @@
+﻿using BlogApp.Application.Features.Users.CQRS.Commands;
+using BlogApp.Application.Features.Users.CQRS.Queries;
+using BlogApp.Application.Features.Users.DTOs;
+using BlogApp.Application.Responses;
+using MediatR;
+using Microsoft.AspNetCore.Mvc;
+
+// For more information on enabling Web API for empty projects, visit https://go.microsoft.com/fwlink/?LinkID=397860
+
+namespace BlogApp.Api.Controllers
+{
+    [Route("api/[Controller]")]
+    [ApiController]
+    public class UserController : ControllerBase
+    {
+        private readonly IMediator _mediator;
+
+        public UserController(IMediator mediator)
+        {
+            _mediator = mediator;
+        }
+
+        [HttpGet]
+        public async Task<ActionResult<List<_UserDto>>> Get()
+        {
+            var users = await _mediator.Send(new Get_UserListQuery());
+            return Ok(users);
+        }
+
+        [HttpGet("{id}")]
+        public async Task<ActionResult<_UserDto>> Get(int id)
+        {
+            var users = await _mediator.Send(new Get_UserDetailQuery { Id = id });
+            return Ok(users);
+        }
+
+        [HttpPost]
+        public async Task<ActionResult<BaseCommandResponse>> Post([FromBody] Create_UserDto create_UserDto)
+        {
+            var command = new Create_UserCommand { Create_UserDto = create_UserDto };
+            var repsonse = await _mediator.Send(command);
+            return Ok(repsonse);
+        }
+
+        [HttpPut]
+        public async Task<ActionResult> Put([FromBody] Update_UserDto userDto)
+        {
+            var command = new Update_UserCommand { Update_UserDto = userDto };
+            await _mediator.Send(command);
+            return NoContent();
+        }
+
+        [HttpDelete("{id}")]
+        public async Task<ActionResult> Delete(int id)
+        {
+            var command = new Delete_UserCommand { Id = id };
+            await _mediator.Send(command);
+            return NoContent();
+        }
+    }
+}

--- a/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.API/Program.cs
+++ b/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.API/Program.cs
@@ -1,6 +1,9 @@
 using BlogApp.Application;
+using BlogApp.Identity;
 using BlogApp.Persistence;
+using BlogApp.Infrastructure;
 using Microsoft.OpenApi.Models;
+using BlogApp.Identity;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -14,6 +17,9 @@ builder.Services.AddControllers();
 // Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();
+builder.Services.ConfigureIdentityServices(builder.Configuration);
+builder.Services.ConfigureInfrastructureServices(builder.Configuration);
+
 
 builder.Services.AddCors(o =>
 {
@@ -49,12 +55,42 @@ void AddSwaggerDoc(IServiceCollection services)
 {
     services.AddSwaggerGen(c =>
     {
+        c.AddSecurityDefinition("Bearer", new OpenApiSecurityScheme
+        {
+            Description = @"JWT Authorization header using the Bearer scheme. 
+                Enter 'Bearer' [space] and then your token in the text input below.
+                Example: 'Bearer 12345abcdef'",
+            Name = "Authorization",
+            In = ParameterLocation.Header,
+            Type = SecuritySchemeType.ApiKey,
+            Scheme = "Bearer"
+        });
+
+        c.AddSecurityRequirement(new OpenApiSecurityRequirement()
+            {
+            {
+                new OpenApiSecurityScheme
+                {
+                Reference = new OpenApiReference
+                    {
+                    Type = ReferenceType.SecurityScheme,
+                    Id = "Bearer"
+                    },
+                    Scheme = "oauth2",
+                    Name = "Bearer",
+                    In = ParameterLocation.Header,
+
+                },
+                new List<string>()
+                }
+            });
+
         c.SwaggerDoc("v1", new OpenApiInfo
         {
             Version = "v1",
-            Title = "Blog App Api",
+            Title = "Blog Api",
 
         });
-
     });
 }
+

--- a/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.API/appsettings.json
+++ b/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.API/appsettings.json
@@ -1,6 +1,7 @@
 {
   "ConnectionStrings": {
-    "BlogAppConnectionString": "User ID=postgres;Password=1234;Server=localhost;port=5432;Database=CleanBlog;Integrated Security=true;pooling=true"
+    "BlogAppConnectionString": "User ID=postgres;Password=#passFunc(13);Server=localhost;Port=5432;Database=CleanArch;Integrated Security=true;Pooling=true;",
+    "BlogIdentityConnectionString": "User ID=postgres;Password=#passFunc(13);Server=localhost;Port=5432;Database=BlogIdentityDb;Integrated Security=true;Pooling=true;"
   },
   "Logging": {
     "LogLevel": {
@@ -8,5 +9,21 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
+
+  "EmailSettings": {
+    "From": "yonassgebre06@gmail.com",
+    "SmtpServer": "smtp.gmail.com",
+    "Port": 465,
+    "UserName": "yonassgebre06@gmail.com",
+    "Password": "coprvcizvtmhggzl"
+  },
+
+  "JwtSettings": {
+    "Key": "2J9JFA9THQTH9AHRHTQ9YAQTJ",
+    "Issuer": "BlogApi",
+    "Audience": "BlogApiUser",
+    "DurationInMinutes": 60
+  },
+  
   "AllowedHosts": "*"
 }

--- a/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.API/appsettings.json
+++ b/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.API/appsettings.json
@@ -24,6 +24,10 @@
     "Audience": "BlogApiUser",
     "DurationInMinutes": 60
   },
+
+  "ServerSettings": {
+    "BaseApiUrl": "https://localhost:7132/api/"
+  },
   
   "AllowedHosts": "*"
 }

--- a/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.Application/ApplicationServicesRegistration.cs
+++ b/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.Application/ApplicationServicesRegistration.cs
@@ -15,6 +15,7 @@ namespace BlogApp.Application
         {
             services.AddAutoMapper(Assembly.GetExecutingAssembly());
             services.AddMediatR(Assembly.GetExecutingAssembly());
+            
             return services;
         }
     }

--- a/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.Application/BlogApp.Application.csproj
+++ b/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.Application/BlogApp.Application.csproj
@@ -5,7 +5,6 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
-    <Folder Include="Constants\" />
     <Folder Include="Contracts\Identity\" />
     <Folder Include="Contracts\Infrastructure\" />
     <Folder Include="Features\Models\" />

--- a/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.Application/Constants/Identity/IAuthService.cs
+++ b/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.Application/Constants/Identity/IAuthService.cs
@@ -1,0 +1,5 @@
+namespace BlogApp.Application.Constants.Identity;
+
+public interface IAuthService
+{
+}

--- a/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.Application/Constants/Identity/IAuthService.cs
+++ b/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.Application/Constants/Identity/IAuthService.cs
@@ -1,5 +1,0 @@
-namespace BlogApp.Application.Constants.Identity;
-
-public interface IAuthService
-{
-}

--- a/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.Application/Contracts/Identity/IAuthService.cs
+++ b/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.Application/Contracts/Identity/IAuthService.cs
@@ -1,0 +1,22 @@
+using BlogApp.Application.Models.Identity;
+using BlogApp.Application.Responses;
+
+namespace BlogApp.Application.Contracts.Identity;
+
+public interface IAuthService
+{
+    public Task<Result<RegistrationResponse>> Register(RegistrationModel request);
+
+    public Task<Result<LoginResponse>> Login(LoginModel request);
+
+    public  Task<Result<string>> ConfirmEmail(string token, string email);
+    
+    public  Task<Result<string>> ForgotPassword(string Email);
+
+    public  Task<Result<string>> ResetPassword(ResetPasswordModel resetPasswordModel);
+
+    public Task<bool> DeleteUser(string Email);
+
+
+
+}

--- a/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.Application/Contracts/Identity/IAuthService.cs
+++ b/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.Application/Contracts/Identity/IAuthService.cs
@@ -9,6 +9,8 @@ public interface IAuthService
 
     public Task<Result<LoginResponse>> Login(LoginModel request);
 
+    public Task<Result<string>> sendConfirmEmailLink(string Email);
+
     public  Task<Result<string>> ConfirmEmail(string token, string email);
     
     public  Task<Result<string>> ForgotPassword(string Email);

--- a/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.Application/Contracts/Infrastructure/IEmailSender.cs
+++ b/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.Application/Contracts/Infrastructure/IEmailSender.cs
@@ -1,0 +1,9 @@
+using BlogApp.Application.Models.Mail;
+using BlogApp.Application.Responses;
+
+namespace BlogApp.Application.Contracts.Identity;
+
+public interface IEmailSender
+{
+    Task<Result<Email>> sendEmail(Email email);
+}

--- a/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.Application/Contracts/Persistence/IUnitOfWork.cs
+++ b/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.Application/Contracts/Persistence/IUnitOfWork.cs
@@ -8,6 +8,7 @@ namespace BlogApp.Application.Contracts.Persistence
 {
     public interface IUnitOfWork : IDisposable
     {
+        I_UserRepository _UserRepository { get; }
         I_IndexRepository _IndexRepository { get; }
         ITagRepository TagRepository {get;}
 

--- a/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.Application/Contracts/Persistence/I_UserRepository.cs
+++ b/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.Application/Contracts/Persistence/I_UserRepository.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using BlogApp.Domain;
+
+namespace BlogApp.Application.Contracts.Persistence
+{
+    public interface I_UserRepository : IGenericRepository<User>
+    {
+    }
+}

--- a/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.Application/Features/Users/CQRS/Commands/Create_UserCommand.cs
+++ b/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.Application/Features/Users/CQRS/Commands/Create_UserCommand.cs
@@ -1,0 +1,12 @@
+using BlogApp.Application.Features.Users.DTOs;
+using BlogApp.Application.Responses;
+using MediatR;
+
+
+namespace BlogApp.Application.Features.Users.CQRS.Commands
+{
+    public class Create_UserCommand: IRequest<BaseCommandResponse>
+    {
+        public Create_UserDto Create_UserDto { get; set; }
+    }
+}

--- a/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.Application/Features/Users/CQRS/Commands/Delete_UserCommand.cs
+++ b/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.Application/Features/Users/CQRS/Commands/Delete_UserCommand.cs
@@ -1,0 +1,10 @@
+using MediatR;
+
+
+namespace BlogApp.Application.Features.Users.CQRS.Commands
+{
+    public class Delete_UserCommand : IRequest
+    {
+        public int Id { get; set; }
+    }
+}

--- a/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.Application/Features/Users/CQRS/Commands/Update_UserCommand.cs
+++ b/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.Application/Features/Users/CQRS/Commands/Update_UserCommand.cs
@@ -1,0 +1,12 @@
+using BlogApp.Application.Features.Users.DTOs;
+using MediatR;
+
+
+namespace BlogApp.Application.Features.Users.CQRS.Commands
+{
+    public class Update_UserCommand : IRequest<Unit>
+    {
+        public Update_UserDto Update_UserDto { get; set; }
+
+    }
+}

--- a/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.Application/Features/Users/CQRS/Handlers/Create_UserCommandHandler.cs
+++ b/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.Application/Features/Users/CQRS/Handlers/Create_UserCommandHandler.cs
@@ -1,0 +1,54 @@
+﻿using AutoMapper;
+using BlogApp.Application.Contracts.Persistence;
+using BlogApp.Application.Features.Users.CQRS.Commands;
+using BlogApp.Application.Features.Users.DTOs.Validators;
+using BlogApp.Application.Responses;
+using MediatR;
+using BlogApp.Domain;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace BlogApp.Application.Features.Users.CQRS.Handlers
+{
+    public class Create_UserCommandHandler : IRequestHandler<Create_UserCommand, BaseCommandResponse>
+    {
+        private readonly IUnitOfWork _unitOfWork;
+        private readonly IMapper _mapper;
+
+        public Create_UserCommandHandler(IUnitOfWork unitOfWork, IMapper mapper)
+        {
+            _unitOfWork = unitOfWork;
+            _mapper = mapper;
+        }
+
+        public async Task<BaseCommandResponse> Handle(Create_UserCommand request, CancellationToken cancellationToken)
+        {
+            var response = new BaseCommandResponse();
+            var validator = new Create_UserDtoValidator();
+            var validationResult = await validator.ValidateAsync(request.Create_UserDto);
+
+            if (validationResult.IsValid == false)
+            {
+                response.Success = false;
+                response.Message = "Creation Failed";
+                response.Errors = validationResult.Errors.Select(q => q.ErrorMessage).ToList();
+            }
+            else
+            {
+                var user = _mapper.Map<User>(request.Create_UserDto);
+
+                user = await _unitOfWork._UserRepository.Add(user);
+                await _unitOfWork.Save();
+
+                response.Success = true;
+                response.Message = "Creation Successful";
+                response.Id = user.Id;
+            }
+
+            return response;
+        }
+    }
+}

--- a/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.Application/Features/Users/CQRS/Handlers/Delete_UserCommandHandler.cs
+++ b/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.Application/Features/Users/CQRS/Handlers/Delete_UserCommandHandler.cs
@@ -1,0 +1,39 @@
+using AutoMapper;
+using BlogApp.Application.Contracts.Persistence;
+using BlogApp.Application.Exceptions;
+using BlogApp.Application.Features.Users.CQRS.Commands;
+using BlogApp.Domain;
+using MediatR;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace BlogApp.Application.Features.Users.CQRS.Handlers
+{
+    public class Delete_UserCommandHandler : IRequestHandler<Delete_UserCommand>
+    {
+        private readonly IUnitOfWork _unitOfWork;
+        private readonly IMapper _mapper;
+
+        public Delete_UserCommandHandler(IUnitOfWork unitOfWork, IMapper mapper)
+        {
+            _unitOfWork = unitOfWork;
+            _mapper = mapper;
+        }
+
+        public async Task<Unit> Handle(Delete_UserCommand request, CancellationToken cancellationToken)
+        {
+            var user = await _unitOfWork._UserRepository.Get(request.Id);
+
+            if (user == null)
+                throw new NotFoundException(nameof(User), request.Id);
+
+            await _unitOfWork._UserRepository.Delete(user);
+            await _unitOfWork.Save();
+
+            return Unit.Value;
+        }
+    }
+}

--- a/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.Application/Features/Users/CQRS/Handlers/Get_UserDetailQueryHandler.cs
+++ b/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.Application/Features/Users/CQRS/Handlers/Get_UserDetailQueryHandler.cs
@@ -1,0 +1,30 @@
+using AutoMapper;
+using BlogApp.Application.Contracts.Persistence;
+using BlogApp.Application.Features.Users.CQRS.Queries;
+using BlogApp.Application.Features.Users.DTOs;
+using MediatR;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace BlogApp.Application.Features.Users.CQRS.Handlers
+{
+    public class Get_UserDetailQueryHandler : IRequestHandler<Get_UserDetailQuery, _UserDto>
+    {
+        private readonly IUnitOfWork _unitOfWork;
+        private readonly IMapper _mapper;
+
+        public Get_UserDetailQueryHandler(IUnitOfWork unitOfWork, IMapper mapper)
+        {
+            _unitOfWork = unitOfWork;
+            _mapper = mapper;
+        }
+        public async Task<_UserDto> Handle(Get_UserDetailQuery request, CancellationToken cancellationToken)
+        {
+            var user = await _unitOfWork._UserRepository.Get(request.Id);
+            return _mapper.Map<_UserDto>(user);
+        }
+    }
+}

--- a/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.Application/Features/Users/CQRS/Handlers/Get_UserListQueryHandler.cs
+++ b/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.Application/Features/Users/CQRS/Handlers/Get_UserListQueryHandler.cs
@@ -25,7 +25,6 @@ namespace BlogApp.Application.Features.Users.CQRS.Handlers
         public async Task<List<_UserDto>> Handle(Get_UserListQuery request, CancellationToken cancellationToken)
         {
             var users = await _unitOfWork._UserRepository.GetAll();
-            Console.Write(users);
             return _mapper.Map<List<_UserDto>>(users);
         }
     }

--- a/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.Application/Features/Users/CQRS/Handlers/Get_UserListQueryHandler.cs
+++ b/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.Application/Features/Users/CQRS/Handlers/Get_UserListQueryHandler.cs
@@ -1,0 +1,32 @@
+using AutoMapper;
+using BlogApp.Application.Contracts.Persistence;
+using BlogApp.Application.Features.Users.CQRS.Queries;
+using BlogApp.Application.Features.Users.DTOs;
+using MediatR;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace BlogApp.Application.Features.Users.CQRS.Handlers
+{
+    public class Get_UserListQueryHandler : IRequestHandler<Get_UserListQuery, List<_UserDto>>
+    {
+        private readonly IUnitOfWork _unitOfWork;
+        private readonly IMapper _mapper;
+
+        public Get_UserListQueryHandler(IUnitOfWork unitOfWork, IMapper mapper)
+        {
+            _unitOfWork = unitOfWork;
+            _mapper = mapper;
+        }
+
+        public async Task<List<_UserDto>> Handle(Get_UserListQuery request, CancellationToken cancellationToken)
+        {
+            var users = await _unitOfWork._UserRepository.GetAll();
+            Console.Write(users);
+            return _mapper.Map<List<_UserDto>>(users);
+        }
+    }
+}

--- a/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.Application/Features/Users/CQRS/Handlers/Update_UserCommandHandler.cs
+++ b/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.Application/Features/Users/CQRS/Handlers/Update_UserCommandHandler.cs
@@ -1,0 +1,49 @@
+using AutoMapper;
+using BlogApp.Application.Responses;
+using BlogApp.Application.Contracts.Persistence;
+using BlogApp.Application.Exceptions;
+using BlogApp.Application.Features.Users.CQRS.Commands;
+using BlogApp.Application.Features.Users.DTOs.Validators;
+using BlogApp.Domain;
+using MediatR;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace BlogApp.Application.Features.Users.CQRS.Handlers
+{
+    public class Update_UserCommandHandler : IRequestHandler<Update_UserCommand, Unit>
+    {
+        private readonly IUnitOfWork _unitOfWork;
+        private readonly IMapper _mapper;
+
+        public Update_UserCommandHandler(IUnitOfWork unitOfWork, IMapper mapper)
+        {
+            _unitOfWork = unitOfWork;
+            _mapper = mapper;
+        }
+
+        public async Task<Unit> Handle(Update_UserCommand request, CancellationToken cancellationToken)
+        {
+            var validator = new Update_UserDtoValidator();
+            var validationResult = await validator.ValidateAsync(request.Update_UserDto);
+
+            if (validationResult.IsValid == false)
+                throw new ValidationException(validationResult);
+
+            var user = await _unitOfWork._UserRepository.Get(request.Update_UserDto.Id);
+
+            if (user is null)
+                throw new NotFoundException(nameof(User), request.Update_UserDto.Id);
+
+            _mapper.Map(request.Update_UserDto, user);
+
+            await _unitOfWork._UserRepository.Update(user);
+            await _unitOfWork.Save();
+
+            return Unit.Value;
+        }
+    }
+}

--- a/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.Application/Features/Users/CQRS/Queries/Get_UserDetailQuery.cs
+++ b/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.Application/Features/Users/CQRS/Queries/Get_UserDetailQuery.cs
@@ -1,0 +1,15 @@
+using BlogApp.Application.Features.Users.DTOs;
+using MediatR;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace BlogApp.Application.Features.Users.CQRS.Queries
+{
+    public class Get_UserDetailQuery : IRequest<_UserDto>
+    {
+        public int Id { get; set; }
+    }
+}

--- a/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.Application/Features/Users/CQRS/Queries/Get_UserListQuery.cs
+++ b/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.Application/Features/Users/CQRS/Queries/Get_UserListQuery.cs
@@ -1,0 +1,14 @@
+using BlogApp.Application.Features.Users.DTOs;
+using MediatR;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace BlogApp.Application.Features.Users.CQRS.Queries
+{
+    public class Get_UserListQuery: IRequest<List<_UserDto>>
+    {
+    }
+}

--- a/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.Application/Features/Users/DTOs/Create_UserDto.cs
+++ b/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.Application/Features/Users/DTOs/Create_UserDto.cs
@@ -1,0 +1,22 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using BlogApp.Domain;
+using BlogApp.Application.Features.Common;
+
+namespace BlogApp.Application.Features.Users.DTOs
+{
+    public class Create_UserDto : I_UserDto
+    {
+        
+        public string FirstName { get; set; }
+
+        public string LastName { get; set; }
+        
+        public string AccountId { get; set; }
+        public string Email { get; set; }
+        public string Password { get; set; }
+    }
+}

--- a/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.Application/Features/Users/DTOs/I_UserDto.cs
+++ b/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.Application/Features/Users/DTOs/I_UserDto.cs
@@ -1,0 +1,19 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using BlogApp.Domain;
+
+
+namespace BlogApp.Application.Features.Users.DTOs
+{
+    public interface I_UserDto
+    {
+        public string FirstName { get; set; }
+        public string LastName { get; set; }
+        public string AccountId { get; set; }
+        public string Email { get; set; }
+        public string Password { get; set; }
+    }
+}

--- a/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.Application/Features/Users/DTOs/RegisterDto.cs
+++ b/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.Application/Features/Users/DTOs/RegisterDto.cs
@@ -1,0 +1,16 @@
+namespace BlogApp.Application.Features.Users.DTOs;
+
+public class RegisterDto
+{
+    public string FirstName { get; set; }
+
+    public string LastName { get; set; }
+    
+    public string Email {get; set;}
+
+    public string UserName {get; set;}
+
+    public string Password{get; set;}
+
+    public ICollection<string> Roles {get; set;}
+}

--- a/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.Application/Features/Users/DTOs/Update_UserDto.cs
+++ b/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.Application/Features/Users/DTOs/Update_UserDto.cs
@@ -1,0 +1,20 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using BlogApp.Domain;
+using BlogApp.Application.Features.Common;
+
+
+namespace BlogApp.Application.Features.Users.DTOs
+{
+    public class Update_UserDto : BaseDto,I_UserDto
+    {
+        public string FirstName { get; set; }
+        public string LastName { get; set; }
+        public string AccountId { get; set; }
+        public string Email { get; set; }
+        public string Password { get; set; }
+    }
+}

--- a/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.Application/Features/Users/DTOs/Validators/Create_UserDtoValidator.cs
+++ b/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.Application/Features/Users/DTOs/Validators/Create_UserDtoValidator.cs
@@ -1,0 +1,20 @@
+using BlogApp.Application.Features.Users.DTOs;
+using BlogApp.Application.Features.Users.DTOs.Validators;
+using FluentValidation;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace BlogApp.Application.Features.Users.DTOs.Validators
+{
+    public class Create_UserDtoValidator : AbstractValidator<Create_UserDto>
+    {
+        public Create_UserDtoValidator()
+        {
+            Include(new I_UserDtoValidator());
+        }
+    }
+
+}

--- a/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.Application/Features/Users/DTOs/Validators/I_UserDtoValidator.cs
+++ b/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.Application/Features/Users/DTOs/Validators/I_UserDtoValidator.cs
@@ -1,0 +1,27 @@
+using BlogApp.Application.Features.Users.DTOs;
+using FluentValidation;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace BlogApp.Application.Features.Users.DTOs.Validators
+{
+    public class I_UserDtoValidator : AbstractValidator<I_UserDto>
+    {
+        public I_UserDtoValidator()
+        {
+        RuleFor(user => user.FirstName)
+            .NotEmpty().WithMessage("{PropertyName} is required.")
+            .Length(2, 50).WithMessage("{PropertyName} must be between 2 and 50 characters.");
+
+        RuleFor(user => user.LastName)
+            .NotEmpty().WithMessage("{PropertyName} is required.")
+            .Length(2, 50).WithMessage("{PropertyName} must be between 2 and 50 characters.");
+        RuleFor(user => user.Email)
+            .NotEmpty().WithMessage("{PropertyName} is required.")
+            .EmailAddress().WithMessage("{PropertyName} is not valid.");
+        }
+    }
+}

--- a/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.Application/Features/Users/DTOs/Validators/Update_UserDtoValidator.cs
+++ b/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.Application/Features/Users/DTOs/Validators/Update_UserDtoValidator.cs
@@ -1,0 +1,20 @@
+using BlogApp.Application.Features.Users.DTOs;
+using FluentValidation;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace BlogApp.Application.Features.Users.DTOs.Validators
+{
+    public class Update_UserDtoValidator : AbstractValidator<Update_UserDto>
+    {
+        public Update_UserDtoValidator()
+        {
+            Include(new I_UserDtoValidator());
+
+            RuleFor(p => p.Id).NotNull().WithMessage("{PropertyName} must be present");
+        }
+    }
+}

--- a/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.Application/Features/Users/DTOs/_UserDto.cs
+++ b/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.Application/Features/Users/DTOs/_UserDto.cs
@@ -1,0 +1,23 @@
+using BlogApp.Application.Features.Common;
+using BlogApp.Domain;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+
+namespace BlogApp.Application.Features.Users.DTOs
+{
+    public class _UserDto : BaseDto, I_UserDto
+    {
+        public string FirstName { get; set; }
+        public string LastName { get; set; }
+        public string AccountId { get; set; }
+        public string Email { get; set; }
+        public string Password { get; set; }
+
+
+
+    }
+}

--- a/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.Application/Models/Identity/ConfirmEmailResponse.cs
+++ b/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.Application/Models/Identity/ConfirmEmailResponse.cs
@@ -2,4 +2,5 @@ namespace BlogApp.Application.Models.Identity;
 
 public class ConfirmEmailResponse
 {
+    public bool Succeeded{get; set;}
 }

--- a/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.Application/Models/Identity/ConfirmEmailResponse.cs
+++ b/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.Application/Models/Identity/ConfirmEmailResponse.cs
@@ -1,0 +1,5 @@
+namespace BlogApp.Application.Models.Identity;
+
+public class ConfirmEmailResponse
+{
+}

--- a/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.Application/Models/Identity/ForgotPasswordResponse.cs
+++ b/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.Application/Models/Identity/ForgotPasswordResponse.cs
@@ -1,0 +1,5 @@
+namespace BlogApp.Application.Models.Identity;
+
+public class ForgotPasswordResponse
+{
+}

--- a/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.Application/Models/Identity/JwtSettings.cs
+++ b/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.Application/Models/Identity/JwtSettings.cs
@@ -1,0 +1,5 @@
+namespace BlogApp.Application.Models.Identity;
+
+public class JwtSettings
+{
+}

--- a/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.Application/Models/Identity/JwtSettings.cs
+++ b/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.Application/Models/Identity/JwtSettings.cs
@@ -2,4 +2,11 @@ namespace BlogApp.Application.Models.Identity;
 
 public class JwtSettings
 {
+    public string Issuer {get; set;} = "";
+
+    public string Audience {get; set;} = "";
+
+    public string Key {get; set;} = "";
+    
+    public int DurationInMinutes {get; set;}
 }

--- a/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.Application/Models/Identity/LoginModel.cs
+++ b/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.Application/Models/Identity/LoginModel.cs
@@ -1,0 +1,5 @@
+namespace BlogApp.Application.Models.Identity;
+
+public class LoginModel
+{
+}

--- a/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.Application/Models/Identity/LoginModel.cs
+++ b/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.Application/Models/Identity/LoginModel.cs
@@ -2,4 +2,7 @@ namespace BlogApp.Application.Models.Identity;
 
 public class LoginModel
 {
+    public string Email { get; set; } = "";
+
+    public string Password { get; set; } = "";
 }

--- a/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.Application/Models/Identity/LoginResponse.cs
+++ b/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.Application/Models/Identity/LoginResponse.cs
@@ -1,0 +1,5 @@
+namespace BlogApp.Application.Models.Identity;
+
+public class LoginResponse
+{
+}

--- a/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.Application/Models/Identity/LoginResponse.cs
+++ b/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.Application/Models/Identity/LoginResponse.cs
@@ -1,5 +1,14 @@
+using BlogApp.Application.Responses;
+
 namespace BlogApp.Application.Models.Identity;
 
 public class LoginResponse
 {
+    public string UserId {get; set;} = "";
+
+    public string Email {get; set;} = "";
+
+    public string UserName {get; set;} = "";
+
+    public string Token {get; set;} = "";
 }

--- a/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.Application/Models/Identity/RegistrationModel.cs
+++ b/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.Application/Models/Identity/RegistrationModel.cs
@@ -1,0 +1,5 @@
+namespace BlogApp.Application.Models.Identity;
+
+public class RegistrationModel
+{
+}

--- a/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.Application/Models/Identity/RegistrationModel.cs
+++ b/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.Application/Models/Identity/RegistrationModel.cs
@@ -1,5 +1,19 @@
+using System.ComponentModel.DataAnnotations;
+
 namespace BlogApp.Application.Models.Identity;
 
 public class RegistrationModel
 {
+    [Required]
+    [EmailAddress]
+    public string Email {get; set;} = "";
+
+    [Required]
+    public string UserName {get; set;} = "";
+
+    [Required]
+    public string Password{get; set;} = "";
+
+    [Required]
+    public ICollection<string> Roles {get; set;}
 }

--- a/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.Application/Models/Identity/RegistrationResponse.cs
+++ b/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.Application/Models/Identity/RegistrationResponse.cs
@@ -7,5 +7,5 @@ public class RegistrationResponse
 {
     public string UserId {get; set;} = "";
 
-    public Email email {get; set;}
+    public string email {get; set;}
 }

--- a/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.Application/Models/Identity/RegistrationResponse.cs
+++ b/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.Application/Models/Identity/RegistrationResponse.cs
@@ -1,0 +1,5 @@
+namespace BlogApp.Application.Models.Identity;
+
+public class RegistrationResponse
+{
+}

--- a/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.Application/Models/Identity/RegistrationResponse.cs
+++ b/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.Application/Models/Identity/RegistrationResponse.cs
@@ -1,5 +1,11 @@
+using BlogApp.Application.Models.Mail;
+using BlogApp.Application.Responses;
+
 namespace BlogApp.Application.Models.Identity;
 
 public class RegistrationResponse
 {
+    public string UserId {get; set;} = "";
+
+    public Email email {get; set;}
 }

--- a/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.Application/Models/Identity/ResetPasswordModel.cs
+++ b/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.Application/Models/Identity/ResetPasswordModel.cs
@@ -1,0 +1,5 @@
+namespace BlogApp.Application.Models.Identity;
+
+public class ResetPasswordModel
+{
+}

--- a/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.Application/Models/Identity/ResetPasswordModel.cs
+++ b/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.Application/Models/Identity/ResetPasswordModel.cs
@@ -2,4 +2,7 @@ namespace BlogApp.Application.Models.Identity;
 
 public class ResetPasswordModel
 {
+    public string Password { get; set; } = "";
+    public string Email { get; set; } = "";
+    public string Token { get; set; } = "";
 }

--- a/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.Application/Models/Identity/ResetPasswordResponse.cs
+++ b/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.Application/Models/Identity/ResetPasswordResponse.cs
@@ -1,0 +1,5 @@
+namespace BlogApp.Application.Models.Identity;
+
+public class ResetPasswordResponse
+{
+}

--- a/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.Application/Models/Identity/ServerSettings.cs
+++ b/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.Application/Models/Identity/ServerSettings.cs
@@ -1,0 +1,7 @@
+namespace BlogApp.Application.Models.Identity;
+
+public class ServerSettings
+{
+    public string BaseApiUrl {get; set;} = "";
+    
+}

--- a/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.Application/Models/Mail/Email.cs
+++ b/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.Application/Models/Mail/Email.cs
@@ -1,0 +1,10 @@
+namespace BlogApp.Application.Models.Mail;
+
+public class Email
+{
+    public string To {get; set;} = "";
+
+    public string Subject {get; set;} = "";
+
+    public string Body {get; set;} = "";
+}

--- a/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.Application/Models/Mail/EmailSettings.cs
+++ b/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.Application/Models/Mail/EmailSettings.cs
@@ -1,0 +1,14 @@
+namespace BlogApp.Application.Models.Mail;
+
+public class EmailSettings
+{
+    public string From { get; set; }
+
+    public string SmtpServer { get; set; }
+
+    public int Port { get; set; }
+
+    public string UserName { get; set; }
+    
+    public string Password { get; set; }
+}

--- a/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.Application/Profiles/MappingProfile.cs
+++ b/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.Application/Profiles/MappingProfile.cs
@@ -4,6 +4,8 @@ using BlogApp.Application.Features.Tags.DTOs;
 using BlogApp.Application.Features.Reviews.DTOs;
 using BlogApp.Application.Features.BlogRates.DTOs;
 using BlogApp.Application.Features.Comments.DTOs;
+using BlogApp.Application.Features.Users.DTOs;
+using BlogApp.Application.Models.Identity;
 using BlogApp.Domain;
 using System;
 using System.Collections.Generic;
@@ -11,6 +13,8 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using BlogApp.Application.Features.Blog.DTOs;
+using BlogApp.Application.Features.Blog.DTOs;
+using BlogApp.Application.Features._Indices.DTOs;
 
 namespace BlogApp.Application.Profiles
 {
@@ -75,6 +79,11 @@ namespace BlogApp.Application.Profiles
             #endregion comment
 
 
+            CreateMap<User, _UserDto>().ReverseMap();
+            CreateMap<User, Create_UserDto>().ReverseMap();
+            CreateMap<User, Update_UserDto>().ReverseMap();
+            CreateMap<RegisterDto, Create_UserDto>().ReverseMap();
+            CreateMap<RegisterDto, RegistrationModel>().ReverseMap();
         }
     }
 }

--- a/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.Application/Responses/Result.cs
+++ b/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.Application/Responses/Result.cs
@@ -5,5 +5,5 @@ public class Result<T>
     public bool Success { get; set; } = true;
     public string Message { get; set; }
     public T? Value { get; set; }
-    public List<string> Errors { get; set; }
+    public List<string> Errors { get; set; } = new List<string>();
 }

--- a/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.Domain/User.cs
+++ b/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.Domain/User.cs
@@ -1,0 +1,24 @@
+﻿using BlogApp.Domain.Common;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace BlogApp.Domain
+
+{
+    public enum UserRole
+    {
+    Admin,User
+    }
+    public class User : BaseDomainEntity
+    {
+        public string FirstName { get; set; }
+        public string LastName { get; set; }
+        public string? Password { get; set; }
+        public string? Email { get; set; }
+        public string AccountId { get; set; }
+       
+    }
+}

--- a/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.Identity/BlogApp.Identity.csproj
+++ b/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.Identity/BlogApp.Identity.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>disable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="6.0.6" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="6.0.6" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity" Version="2.2.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="6.0.6" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="6.0.6">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="6.0.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.30.0" />
+  </ItemGroup>
+</Project>

--- a/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.Identity/BlogApp.Identity.csproj
+++ b/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.Identity/BlogApp.Identity.csproj
@@ -17,4 +17,7 @@
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.30.0" />
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\BlogApp.Application\BlogApp.Application.csproj" />
+  </ItemGroup>
 </Project>

--- a/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.Identity/BlogAppDbContext.cs
+++ b/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.Identity/BlogAppDbContext.cs
@@ -1,5 +1,24 @@
+using BlogApp.Identity.Configurations;
+using BlogApp.Identity.Models;
+using Microsoft.AspNetCore.Identity.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore;
+
 namespace BlogApp.Identity;
 
-public class BlogAppDbContext
+public class BlogAppIdentityDbContext : IdentityDbContext<BlogUser>
 {
+    public BlogAppIdentityDbContext(DbContextOptions<BlogAppIdentityDbContext> options) :
+        base(options)
+    {
+
+    }
+
+    protected override void OnModelCreating(ModelBuilder builder)
+    {
+        base.OnModelCreating(builder);
+
+        builder.ApplyConfiguration(new RoleConfiguration());
+        builder.ApplyConfiguration(new UserConfiguration());
+        builder.ApplyConfiguration(new UserRoleConfiguration());
+    }
 }

--- a/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.Identity/BlogAppDbContext.cs
+++ b/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.Identity/BlogAppDbContext.cs
@@ -1,0 +1,5 @@
+namespace BlogApp.Identity;
+
+public class BlogAppDbContext
+{
+}

--- a/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.Identity/BlogAppDbContextFactory.cs
+++ b/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.Identity/BlogAppDbContextFactory.cs
@@ -1,5 +1,24 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Design;
+using Microsoft.Extensions.Configuration;
+
 namespace BlogApp.Identity;
 
-public class BlogAppDbContextFactory
+
+public class BlogAppIdentityDbContextFactory : IDesignTimeDbContextFactory<BlogAppIdentityDbContext>
 {
+    public BlogAppIdentityDbContext CreateDbContext(string[] args)
+    {
+        IConfigurationRoot configuration = new ConfigurationBuilder()
+            .SetBasePath(Directory.GetCurrentDirectory() + "../../BlogApp.Api")
+            .AddJsonFile("appsettings.json")
+            .Build();
+
+        var builder = new DbContextOptionsBuilder<BlogAppIdentityDbContext>();
+        var connectionString = configuration.GetConnectionString("BlogIdentityConnectionString");
+
+        builder.UseNpgsql(connectionString);
+
+        return new BlogAppIdentityDbContext(builder.Options);
+    }
 }

--- a/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.Identity/BlogAppDbContextFactory.cs
+++ b/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.Identity/BlogAppDbContextFactory.cs
@@ -1,0 +1,5 @@
+namespace BlogApp.Identity;
+
+public class BlogAppDbContextFactory
+{
+}

--- a/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.Identity/Configurations/RoleConfiguration.cs
+++ b/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.Identity/Configurations/RoleConfiguration.cs
@@ -1,0 +1,5 @@
+namespace BlogApp.Identity.Configurations;
+
+public class RoleConfiguration
+{
+}

--- a/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.Identity/Configurations/RoleConfiguration.cs
+++ b/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.Identity/Configurations/RoleConfiguration.cs
@@ -1,5 +1,27 @@
+using Microsoft.AspNetCore.Identity;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
 namespace BlogApp.Identity.Configurations;
 
-public class RoleConfiguration
+public class RoleConfiguration : IEntityTypeConfiguration<IdentityRole>
 {
+    public void Configure(EntityTypeBuilder<IdentityRole> builder)
+    {
+        builder.HasData(
+            new IdentityRole
+            {
+                Id = "51aa4c19-c079-4beb-b223-f3b2b6d3d71c",
+                Name = "User",
+                NormalizedName = "USER"
+            },
+    
+            new IdentityRole
+            {
+                Id = "a9b1000b-3331-4e6d-8777-cc1251eb68d6",
+                Name = "Admin",
+                NormalizedName = "ADMIN"
+            }
+        );
+    }
 }

--- a/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.Identity/Configurations/UserConfiguration.cs
+++ b/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.Identity/Configurations/UserConfiguration.cs
@@ -1,0 +1,5 @@
+namespace BlogApp.Identity.Configurations;
+
+public class UserConfiguration
+{
+}

--- a/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.Identity/Configurations/UserConfiguration.cs
+++ b/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.Identity/Configurations/UserConfiguration.cs
@@ -1,5 +1,37 @@
+using BlogApp.Identity.Models;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
 namespace BlogApp.Identity.Configurations;
 
-public class UserConfiguration
+public class UserConfiguration : IEntityTypeConfiguration<BlogUser>
 {
+    public void Configure(EntityTypeBuilder<BlogUser> builder)
+    {
+        var hasher = new PasswordHasher<BlogUser>();
+        builder.HasData(
+            new BlogUser
+            {
+                Id = "4000b844-74ca-479b-badb-4f41850ae07e",
+                Email = "Admin@HR.com",
+                NormalizedEmail = "ADMIN@HR.COM",
+                UserName = "Admin@HR.com",
+                NormalizedUserName = "ADMIN@HR.COM",
+                PasswordHash = hasher.HashPassword(null, "P@ssword1"),
+                EmailConfirmed = false
+            },
+
+            new BlogUser
+            {
+                Id = "efa06a55-d0cc-4e01-abbf-870f21d91441",
+                Email = "User@HR.com",
+                NormalizedEmail = "USER@HR.COM",
+                UserName = "User@HR.com",
+                NormalizedUserName = "USER@HR.COM",
+                PasswordHash = hasher.HashPassword(null, "P@ssword2"),
+                EmailConfirmed = false
+            }
+        );
+    }
 }

--- a/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.Identity/Configurations/UserRoleConfiguration.cs
+++ b/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.Identity/Configurations/UserRoleConfiguration.cs
@@ -1,5 +1,25 @@
+using Microsoft.AspNetCore.Identity;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
 namespace BlogApp.Identity.Configurations;
 
-public class UserRoleConfiguration
+public class UserRoleConfiguration : IEntityTypeConfiguration<IdentityUserRole<string>>
 {
+    public void Configure(EntityTypeBuilder<IdentityUserRole<string>> builder)
+    {
+        builder.HasData(
+            new IdentityUserRole<string>
+            {
+                UserId = "4000b844-74ca-479b-badb-4f41850ae07e",
+                RoleId = "51aa4c19-c079-4beb-b223-f3b2b6d3d71c"
+            },
+            new IdentityUserRole<string>
+            {
+                UserId = "efa06a55-d0cc-4e01-abbf-870f21d91441",
+                RoleId = "a9b1000b-3331-4e6d-8777-cc1251eb68d6"
+            }
+
+        );
+    }
 }

--- a/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.Identity/Configurations/UserRoleConfiguration.cs
+++ b/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.Identity/Configurations/UserRoleConfiguration.cs
@@ -1,0 +1,5 @@
+namespace BlogApp.Identity.Configurations;
+
+public class UserRoleConfiguration
+{
+}

--- a/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.Identity/IdentityServiceRegistration.cs
+++ b/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.Identity/IdentityServiceRegistration.cs
@@ -1,0 +1,5 @@
+namespace BlogApp.Identity;
+
+public class IdentityServiceRegistration
+{
+}

--- a/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.Identity/IdentityServiceRegistration.cs
+++ b/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.Identity/IdentityServiceRegistration.cs
@@ -19,6 +19,7 @@ public static class IdentityServiceRegistration
                                                                   IConfiguration configuration)
     {
         services.Configure<JwtSettings>(configuration.GetSection("JwtSettings"));
+        services.Configure<ServerSettings>(configuration.GetSection("ServerSettings"));
         services.AddDbContext<BlogAppIdentityDbContext>(options =>
         options.UseNpgsql(
             configuration.GetConnectionString("BlogIdentityConnectionString"

--- a/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.Identity/IdentityServiceRegistration.cs
+++ b/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.Identity/IdentityServiceRegistration.cs
@@ -1,5 +1,57 @@
+using System.Text;
+using BlogApp.Identity.Models;
+using BlogApp.Identity.Services;
+using BlogApp.Application.Contracts.Identity;
+using BlogApp.Application.Models;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.IdentityModel.Tokens;
+using BlogApp.Application.Models.Identity;
+
 namespace BlogApp.Identity;
 
-public class IdentityServiceRegistration
+public static class IdentityServiceRegistration
 {
+    public static IServiceCollection ConfigureIdentityServices(this IServiceCollection services,
+                                                                  IConfiguration configuration)
+    {
+        services.Configure<JwtSettings>(configuration.GetSection("JwtSettings"));
+        services.AddDbContext<BlogAppIdentityDbContext>(options =>
+        options.UseNpgsql(
+            configuration.GetConnectionString("BlogIdentityConnectionString"
+            ),
+        options => options.MigrationsAssembly(typeof(BlogAppIdentityDbContext).Assembly.FullName)));
+
+        services.AddIdentity<BlogUser, IdentityRole>()
+        .AddEntityFrameworkStores<BlogAppIdentityDbContext>()
+        .AddDefaultTokenProviders();
+
+        services.AddTransient<IAuthService, AuthService>();
+        services.Configure<DataProtectionTokenProviderOptions>(opt =>
+                        opt.TokenLifespan = TimeSpan.FromHours(2));
+
+        services.AddAuthentication(options =>
+        {
+            options.DefaultAuthenticateScheme = JwtBearerDefaults.AuthenticationScheme;
+            options.DefaultChallengeScheme = JwtBearerDefaults.AuthenticationScheme;
+        })
+        .AddJwtBearer(options =>
+        {
+            options.TokenValidationParameters = new TokenValidationParameters
+            {
+                ValidateIssuerSigningKey = true,
+                ValidateIssuer = true,
+                ValidateAudience = true,
+                ValidateLifetime = true,
+                ClockSkew = TimeSpan.Zero,
+                ValidIssuer = configuration["JwtSettings:Issuer"],
+                ValidAudience = configuration["JwtSettings:Audience"],
+                IssuerSigningKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(configuration["JwtSettings:Key"]))
+            };
+        });
+        return services;
+    }
 }

--- a/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.Identity/Models/BlogUser.cs
+++ b/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.Identity/Models/BlogUser.cs
@@ -1,0 +1,5 @@
+namespace BlogApp.Identity.Models;
+
+public class BlogUser
+{
+}

--- a/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.Identity/Models/BlogUser.cs
+++ b/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.Identity/Models/BlogUser.cs
@@ -1,5 +1,7 @@
+using Microsoft.AspNetCore.Identity;
+
 namespace BlogApp.Identity.Models;
 
-public class BlogUser
+public class BlogUser: IdentityUser
 {
 }

--- a/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.Identity/Services/AuthService.cs
+++ b/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.Identity/Services/AuthService.cs
@@ -1,5 +1,260 @@
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+using System.Text;
+using BlogApp.Application.Contracts.Identity;
+using BlogApp.Application.Models.Identity;
+using BlogApp.Application.Models.Mail;
+using BlogApp.Application.Responses;
+using BlogApp.Identity.Models;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.Options;
+using Microsoft.IdentityModel.Tokens;
+
 namespace BlogApp.Identity.Services;
 
-public class AuthService
+public class AuthService: IAuthService
 {
+    private readonly UserManager<BlogUser> _userManager;
+    private readonly SignInManager<BlogUser> _signInManager;
+    private readonly IEmailSender _emailSender;
+    private readonly JwtSettings _jwtSettings;
+
+    public AuthService(UserManager<BlogUser> userManager,
+                       SignInManager<BlogUser> signInManager,
+                       IOptions<JwtSettings> jwtSettings,
+                       IEmailSender emailSender)
+    {
+        _userManager = userManager;
+        _signInManager = signInManager;
+        _emailSender = emailSender;
+        _jwtSettings = jwtSettings.Value;
+    }
+    public async Task<Result<string>> ConfirmEmail(string token, string email)
+    {
+        var result = new Result<string>();
+        var user = await _userManager.FindByEmailAsync(email);
+        if (user == null)
+        {
+            result.Success = false;
+            result.Errors.Add($"User with email ({email}) not found");
+            return result;
+        }
+        
+        var confirmResult = await _userManager.ConfirmEmailAsync(user, token);
+        if (!confirmResult.Succeeded)
+        {
+            result.Success = false;
+            foreach(var Error in confirmResult.Errors)
+            {
+                result.Errors.Add(Error.Description);
+            }
+            return result;
+        }
+
+        result.Success = true;
+        result.Value = email;
+        return result;
+
+    }
+
+    public async Task<Result<LoginResponse>> Login(LoginModel request)
+    {
+        Result<LoginResponse> result = new Result<LoginResponse>();
+        var user = await _userManager.FindByEmailAsync(request.Email);
+        if (user == null)
+        {
+            result.Success = false;
+            result.Errors.Add($"User with given Email({request.Email}) doesn't exist");
+            return result;
+        }
+
+        var res = await _signInManager.PasswordSignInAsync(user.UserName, request.Password, false, lockoutOnFailure: false);
+        if(!res.Succeeded)
+        {
+            result.Success = false;
+            result.Errors.Add($"Incorrect password");
+            return result;
+        }
+
+        JwtSecurityToken token = await GenerateToken(user);
+
+        var response = new LoginResponse()
+        {
+            UserId = user.Id,
+            UserName = user.UserName,
+            Email = user.Email,
+            Token = new JwtSecurityTokenHandler().WriteToken(token)
+        };
+    
+        result.Value = response;
+        return result;
+    }
+
+
+    private async Task<JwtSecurityToken> GenerateToken(BlogUser user)
+    {
+        var userClaims = await _userManager.GetClaimsAsync(user);
+        var roles = await _userManager.GetRolesAsync(user);
+
+        var roleClaims = new List<Claim>();
+        foreach(var role in roles)
+        {
+            roleClaims.Add(new Claim(ClaimTypes.Role, role));
+        }
+
+        var Claims = new List<Claim>()
+        {
+            new Claim(JwtRegisteredClaimNames.Sub, user.UserName),
+            new Claim(JwtRegisteredClaimNames.Jti, Guid.NewGuid().ToString()),
+            new Claim(JwtRegisteredClaimNames.Email, user.Email),
+            new Claim("uid", user.Id)
+        }.Union(userClaims)
+         .Union(roleClaims);
+
+        var symmetricSecurityKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(_jwtSettings.Key));
+        var signingCredential = new SigningCredentials(symmetricSecurityKey, SecurityAlgorithms.HmacSha256);
+
+        var token = new JwtSecurityToken(
+            issuer: _jwtSettings.Issuer,
+            audience: _jwtSettings.Audience,
+            claims: Claims,
+            expires: DateTime.UtcNow.AddMinutes(_jwtSettings.DurationInMinutes),
+            signingCredentials: signingCredential
+        );
+
+        return token;
+    }
+
+    public async Task<Result<RegistrationResponse>> Register(RegistrationModel request)
+    {
+        var result = new Result<RegistrationResponse>();
+        var existingUser = await _userManager.FindByEmailAsync(request.Email);
+        if(existingUser != null)
+        {
+            result.Success = false;
+            result.Errors.Add($"User with given Email({request.Email}) already exists");
+            return result;
+        }
+
+        var user = new BlogUser{
+            UserName = request.UserName,
+            Email = request.Email,
+            EmailConfirmed = false
+        };
+
+        var createResult = await _userManager.CreateAsync(user, request.Password);
+
+        if(!createResult.Succeeded)
+        {
+            result.Success = false;
+            foreach(var Error in createResult.Errors)
+            {
+                result.Errors.Add(Error.Description);
+            }
+            return result;
+        }
+
+        var createdUser = await _userManager.FindByNameAsync(request.UserName);
+        var token = await _userManager.GenerateEmailConfirmationTokenAsync(createdUser);
+
+        string connectionLink = "todo";
+
+        var message = new Email{
+            To = request.Email,
+            Subject = "Email Confirmation",
+            Body = $"Email Confirmation link: {connectionLink}\n token: {token}"
+        };
+        
+        
+        await _userManager.AddToRolesAsync(createdUser, request.Roles);
+        var emailResult = await _emailSender.sendEmail(message);
+        result.Errors.AddRange(emailResult.Errors);
+        
+        result.Success = true;
+        result.Value = new RegistrationResponse
+        {
+            UserId = createdUser.Id,
+            email = emailResult.Value
+        };
+
+        return result;
+    }
+
+    public async Task<Result<string>> ForgotPassword(string Email)
+    {
+        var result = new Result<string>();
+        var user = await _userManager.FindByEmailAsync(Email);
+        if (user == null)
+        {
+            result.Success = false;
+            result.Errors.Add($"User with email ({Email}) not found");
+            return result;
+        }
+
+        if (!user.EmailConfirmed)
+        {
+            result.Success = false;
+            result.Errors.Add($"User has not confirmed the email ({Email})");
+            return result;
+        }
+        
+        var token = await _userManager.GeneratePasswordResetTokenAsync(user);
+        string resetLink = "#todo";
+        var message = new Email{
+            To =Email,
+            Subject = "Password Reset",
+            Body = $"Password Reset link: {resetLink} \n token: {token}"
+        };
+
+        var emailResult = await _emailSender.sendEmail(message);
+        if (!emailResult.Success)
+        {
+            result.Success = false;
+            result.Errors.AddRange(emailResult.Errors);
+            return result;
+        }
+
+        result.Success = true;
+        result.Value = Email;
+        return result;
+
+    }
+
+    public async Task<Result<string>> ResetPassword(ResetPasswordModel resetPasswordModel)
+    {
+        var result = new Result<string>();
+        var user = await _userManager.FindByEmailAsync(resetPasswordModel.Email);
+        if (user == null)
+        {
+            result.Success = false;
+            result.Errors.Add($"User with email ({resetPasswordModel.Email}) not found");
+            return result;
+        }
+
+        var resetPassResult = await _userManager.ResetPasswordAsync(user, resetPasswordModel.Token, resetPasswordModel.Password);
+        if(!resetPassResult.Succeeded)
+        {
+            result.Success = false;
+            foreach(var Error in resetPassResult.Errors)
+            {
+                result.Errors.Add(Error.Description);
+            }
+            return result;
+        }
+
+        result.Success = true;
+        result.Value = resetPasswordModel.Email;
+        return result;
+    }
+
+    public async Task<bool> DeleteUser(string Email)
+    {
+        var user = await _userManager.FindByEmailAsync(Email);
+        if (user == null)
+            return false;
+
+        var result = await _userManager.DeleteAsync(user);
+        return result.Succeeded;
+    }
+
 }

--- a/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.Identity/Services/AuthService.cs
+++ b/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.Identity/Services/AuthService.cs
@@ -1,0 +1,5 @@
+namespace BlogApp.Identity.Services;
+
+public class AuthService
+{
+}

--- a/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.Infrastructure/BlogApp.Infrastructure.csproj
+++ b/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.Infrastructure/BlogApp.Infrastructure.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="6.0.0" />
+    <PackageReference Include="NETCore.MailKit" Version="2.1.0" />
+    <PackageReference Include="SendGrid" Version="9.28.1" />
+    <PackageReference Include="SendGrid.Extensions.DependencyInjection" Version="1.0.1" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\BlogApp.Application\BlogApp.Application.csproj" />
+  </ItemGroup>
+</Project>

--- a/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.Infrastructure/InfrastructureServiceRegistration.cs
+++ b/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.Infrastructure/InfrastructureServiceRegistration.cs
@@ -1,0 +1,20 @@
+using BlogApp.Application.Contracts.Identity;
+using BlogApp.Application.Models.Mail;
+using BlogApp.Infrastructure.Mail;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace BlogApp.Infrastructure;
+
+public static class InfrastructureServiceRegistration
+{
+    public static IServiceCollection ConfigureInfrastructureServices(this IServiceCollection services, IConfiguration configuration)
+    {
+        services.Configure<EmailSettings>(configuration.GetSection("EmailSettings"));
+        services.AddTransient<IEmailSender, EmailSender>();
+
+        return services;
+    }
+}
+
+

--- a/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.Infrastructure/Mail/EmailSender.cs
+++ b/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.Infrastructure/Mail/EmailSender.cs
@@ -1,0 +1,62 @@
+using BlogApp.Application.Contracts.Identity;
+using BlogApp.Application.Models.Mail;
+using BlogApp.Application.Responses;
+using MailKit.Net.Smtp;
+using MailKit.Security;
+using Microsoft.Extensions.Options;
+using MimeKit;
+
+namespace BlogApp.Infrastructure.Mail;
+
+public class EmailSender : IEmailSender
+{
+    private readonly EmailSettings _emailSettings;
+
+    public EmailSender(IOptions<EmailSettings> emailSettings)
+    {
+        _emailSettings = emailSettings.Value;
+    }
+
+    private MimeMessage CreateEmailMessage(Email email)
+    {
+        var emailMessage = new MimeMessage();
+        emailMessage.From.Add(new MailboxAddress("email", _emailSettings.From));
+        emailMessage.To.Add(new MailboxAddress("email", email.To));
+        emailMessage.Subject = email.Subject;
+        emailMessage.Body = new TextPart(MimeKit.Text.TextFormat.Text) { Text = email.Body };
+        return emailMessage;
+    }
+
+    public async Task<Result<Email>> sendEmail(Email email)
+    {
+        var result = new Result<Email>();
+        result.Success = true;
+
+        using var client = new SmtpClient();
+        try
+        {
+            await client.ConnectAsync(_emailSettings.SmtpServer, _emailSettings.Port, true);
+            client.AuthenticationMechanisms.Remove("XOAUTH2");
+            await client.AuthenticateAsync(_emailSettings.UserName, _emailSettings.Password);
+            var sent = await client.SendAsync(CreateEmailMessage(email));
+        }
+        catch(Exception ex)
+        {
+            //log an error message or throw an exception or both.
+            result.Success = false;
+            result.Errors.Add(ex.Message);
+            
+        }
+        finally
+        {
+            await client.DisconnectAsync(true);
+            client.Dispose();
+        }
+        
+
+        if(result.Success)
+            result.Value = email;
+
+        return result;
+    }
+}

--- a/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.Persistence/BlogAppDbContext.cs
+++ b/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.Persistence/BlogAppDbContext.cs
@@ -7,6 +7,7 @@ using System.Text;
 using System.Threading.Tasks;
 using BlogApp.Domain;
 using BlogApp.Domain.Common;
+using BlogApp.Domain;
 
 namespace BlogApp.Persistence
 {
@@ -26,7 +27,7 @@ namespace BlogApp.Persistence
            : base(options)
         {
             AppContext.SetSwitch("Npgsql.EnableLegacyTimestampBehavior", true);
-            AppContext.SetSwitch("Npgsql.DisableDateTimeInfinityConversions", true);
+            // AppContext.SetSwitch("Npgsql.DisableDateTimeInfinityConversions", true);
         }
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
@@ -39,20 +40,18 @@ namespace BlogApp.Persistence
 
             foreach (var entry in ChangeTracker.Entries<BaseDomainEntity>())
             {
-                entry.Entity.LastModifiedDate = DateTime.Now;
+                entry.Entity.LastModifiedDate = DateTime.UtcNow;
 
                 if (entry.State == EntityState.Added)
                 {
-                    entry.Entity.DateCreated = DateTime.Now;
+                    entry.Entity.DateCreated = DateTime.UtcNow;
                 }
             }
 
             return base.SaveChangesAsync(cancellationToken);
         }
 
-        
-      
-
+        public DbSet<User> Users { get; set; }
 
     }
 }

--- a/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.Persistence/BlogAppDbContextFactory.cs
+++ b/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.Persistence/BlogAppDbContextFactory.cs
@@ -15,7 +15,7 @@ namespace BlogApp.Persistence
         public BlogAppDbContext CreateDbContext(string[] args)
         {
             IConfigurationRoot configuration = new ConfigurationBuilder()
-                 .SetBasePath(Directory.GetCurrentDirectory())
+                 .SetBasePath(Directory.GetCurrentDirectory() + "../../BlogApp.Api")
                  .AddJsonFile("appsettings.json")
                  .Build();
 

--- a/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.Persistence/Configurations/Entities/_UserConfiguration.cs
+++ b/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.Persistence/Configurations/Entities/_UserConfiguration.cs
@@ -9,21 +9,25 @@ using BlogApp.Domain;
 
 namespace BlogApp.Persistence.Configurations.Entities
 {
-    public class LeaveTypeConfiguration : IEntityTypeConfiguration<_Index>
+    public class UserConfiguration : IEntityTypeConfiguration<User>
     {
-        public void Configure(EntityTypeBuilder<_Index> builder)
+        public void Configure(EntityTypeBuilder<User> builder)
         {
             builder.HasData(
-                new _Index
+                new User
                 {
                     Id = 1,
-                    Name = "First Index"
+                    FirstName = "Abebe",
+                    LastName = "kebede",
+                    AccountId = "abe1"
                 },
 
-                new _Index
+                new User
                 {
                     Id = 2,
-                    Name = "Second Index"
+                    FirstName = "Alemu",
+                    LastName = "Lula",
+                    AccountId = "Lula1"
                 }
                 );
         }

--- a/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.Persistence/PersistenceServicesRegistration.cs
+++ b/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.Persistence/PersistenceServicesRegistration.cs
@@ -18,6 +18,9 @@ namespace BlogApp.Persistence
             services.AddDbContext<BlogAppDbContext>(opt =>
             opt.UseNpgsql(configuration.GetConnectionString("BlogAppConnectionString")));
             services.AddScoped<IUnitOfWork, UnitOfWork>();
+            services.AddScoped(typeof(IGenericRepository<>), typeof(GenericRepository<>));
+            services.AddScoped<I_UserRepository, _UserRepository>();
+            services.AddScoped<IBlogRepository, BlogRepository>();
             services.AddScoped<I_IndexRepository, _IndexRepository>();
             services.AddScoped<IBlogRateRepository, BlogRateRepository>();
             services.AddScoped<IBlogRepository, BlogRepository>();

--- a/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.Persistence/Repositories/UnitOfWork.cs
+++ b/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.Persistence/Repositories/UnitOfWork.cs
@@ -19,18 +19,19 @@ namespace BlogApp.Persistence.Repositories
         private IBlogRateRepository _blogRateRepository;
         private ICommentRepository _commentRepository;
 
+        private I_UserRepository _userRepository;
+    
         public UnitOfWork(BlogAppDbContext context)
         {
             _context = context;
         }
 
-
-        public I_IndexRepository _IndexRepository { 
+        public I_UserRepository _UserRepository { 
             get 
             {
-                if (_indexRepository == null)
-                    _indexRepository = new _IndexRepository(_context);
-                return _indexRepository; 
+                if (_userRepository == null)
+                    _userRepository = new _UserRepository(_context);
+                return _userRepository;
             } 
          }
           public ITagRepository TagRepository { 
@@ -80,12 +81,21 @@ namespace BlogApp.Persistence.Repositories
             } 
          }
 
+        public I_IndexRepository _IndexRepository { 
+            get 
+            {
+                if (_indexRepository == null)
+                    _indexRepository = new _IndexRepository(_context);
+                return _indexRepository; 
+            } 
+        }
+
+
         public void Dispose()
         {
             _context.Dispose();
             GC.SuppressFinalize(this);
         }
-        
         public async Task<int> Save()
         {
             return await _context.SaveChangesAsync();

--- a/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.Persistence/Repositories/_UserRepository.cs
+++ b/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.Persistence/Repositories/_UserRepository.cs
@@ -1,0 +1,20 @@
+﻿using BlogApp.Application.Contracts.Persistence;
+using BlogApp.Domain;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace BlogApp.Persistence.Repositories
+{
+    public class _UserRepository : GenericRepository<User>, I_UserRepository
+    {
+        private readonly BlogAppDbContext _dbContext;
+
+        public _UserRepository(BlogAppDbContext dbContext) : base(dbContext)
+        {
+            _dbContext = dbContext;
+        }
+    }
+}

--- a/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.Tests/Blog/Command/CreateBlogCommandHandlerTest.cs
+++ b/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.Tests/Blog/Command/CreateBlogCommandHandlerTest.cs
@@ -4,7 +4,6 @@ using BlogApp.Application.Features.Blog.CQRS.Handlers.Commands;
 using BlogApp.Application.Features.Blog.CQRS.Requests.Commands;
 using BlogApp.Application.Profiles;
 using AutoMapper;
-using BlogApp.Application.Tests.Mocks;
 using Shouldly;
 using Moq;
 using Xunit;

--- a/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.Tests/Blog/Command/DeleteBlogCommandHandler.cs
+++ b/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.Tests/Blog/Command/DeleteBlogCommandHandler.cs
@@ -4,7 +4,6 @@ using BlogApp.Application.Features.Blog.DTOs;
 using BlogApp.Application.Features.Blog.CQRS.Requests.Commands;
 using BlogApp.Application.Profiles;
 using AutoMapper;
-using BlogApp.Application.Tests.Mocks;
 using Shouldly;
 using Moq;
 using BlogApp.Tests.Mocks;

--- a/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.Tests/Blog/Command/UpdateBlogCommandHandlerTest.cs
+++ b/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.Tests/Blog/Command/UpdateBlogCommandHandlerTest.cs
@@ -4,7 +4,6 @@ using BlogApp.Application.Features.Blog.CQRS.Handlers.Commands;
 using BlogApp.Application.Features.Blog.CQRS.Requests.Commands;
 using BlogApp.Application.Profiles;
 using AutoMapper;
-using BlogApp.Application.Tests.Mocks;
 using Shouldly;
 using Moq;
 using Xunit;

--- a/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.Tests/Blog/Query/GetBlogDetailsQuery.cs
+++ b/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.Tests/Blog/Query/GetBlogDetailsQuery.cs
@@ -3,7 +3,6 @@ using BlogApp.Application.Features.Blog.CQRS.Handlers.Queries;
 using BlogApp.Application.Features.Blog.CQRS.Requests.Queries;
 using BlogApp.Application.Profiles;
 using AutoMapper;
-using BlogApp.Application.Tests.Mocks;
 using Shouldly;
 using Moq;
 using BlogApp.Tests.Mocks;

--- a/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.Tests/Blog/Query/GetBlogListQueryTest.cs
+++ b/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.Tests/Blog/Query/GetBlogListQueryTest.cs
@@ -3,7 +3,6 @@ using BlogApp.Application.Features.Blog.CQRS.Handlers.Queries;
 using BlogApp.Application.Features.Blog.CQRS.Requests.Queries;
 using BlogApp.Application.Profiles;
 using AutoMapper;
-using BlogApp.Application.Tests.Mocks;
 using Shouldly;
 using Moq;
 using BlogApp.Tests.Mocks;

--- a/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.Tests/BlogApp.Tests.csproj
+++ b/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.Tests/BlogApp.Tests.csproj
@@ -6,6 +6,7 @@
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="FluentAssertions" Version="6.11.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
     <PackageReference Include="Moq" Version="4.18.4" />
     <PackageReference Include="Shouldly" Version="4.2.1" />

--- a/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.Tests/BlogRates/CreateBlogRateCommandHandlerTest.cs
+++ b/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.Tests/BlogRates/CreateBlogRateCommandHandlerTest.cs
@@ -3,7 +3,6 @@ using BlogApp.Application.Features.BlogRates.DTOs;
 using BlogApp.Application.Features.BlogRates.CQRS.Commands;
 using BlogApp.Application.Profiles;
 using AutoMapper;
-using BlogApp.Application.Tests.Mocks;
 using Shouldly;
 using Moq;
 using Xunit;

--- a/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.Tests/BlogRates/DeleteBlogRateCommandHandlerTest.cs
+++ b/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.Tests/BlogRates/DeleteBlogRateCommandHandlerTest.cs
@@ -4,13 +4,13 @@ using BlogApp.Application.Features.Blog.DTOs;
 using BlogApp.Application.Features.Blog.CQRS.Requests.Commands;
 using BlogApp.Application.Profiles;
 using AutoMapper;
-using BlogApp.Application.Tests.Mocks;
 using Shouldly;
 using Moq;
 using Xunit;
 using BlogApp.Application.Features.BlogRates.CQRS.Commands;
 using BlogApp.Application.Features.BlogRates.DTOs;
 using Application.Features.BlogRates.Handlers.Commands;
+using BlogApp.Tests.Mocks;
 
 namespace BlogApp.Tests.Blog.Command;
 

--- a/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.Tests/BlogRates/GetBlogRateListByBlogRequestHandlerTest.cs
+++ b/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.Tests/BlogRates/GetBlogRateListByBlogRequestHandlerTest.cs
@@ -5,7 +5,7 @@ using BlogApp.Application.Features.BlogRates.CQRS.Handlers;
 using BlogApp.Application.Features.BlogRates.CQRS.Queries;
 using BlogApp.Application.Features.BlogRates.DTOs;
 using BlogApp.Application.Profiles;
-using BlogApp.Application.Tests.Mocks;
+using BlogApp.Tests.Mocks;
 using Moq;
 using Shouldly;
 using System;

--- a/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.Tests/Comment/Command/CreateCommentCommandHandlerTest.cs
+++ b/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.Tests/Comment/Command/CreateCommentCommandHandlerTest.cs
@@ -4,7 +4,7 @@ using BlogApp.Application.Features.Comments.CQRS.Commands;
 using BlogApp.Application.Features.Comments.CQRS.Handlers;
 using BlogApp.Application.Features.Comments.DTOs;
 using BlogApp.Application.Profiles;
-using BlogApp.Application.Tests.Mocks;
+using BlogApp.Tests.Mocks;
 using Moq;
 using Shouldly;
 using Xunit;

--- a/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.Tests/Comment/Command/DeleteCommentCommandHandlerTest.cs
+++ b/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.Tests/Comment/Command/DeleteCommentCommandHandlerTest.cs
@@ -4,7 +4,7 @@ using BlogApp.Application.Features.Blog.DTOs;
 using BlogApp.Application.Features.Blog.CQRS.Requests.Commands;
 using BlogApp.Application.Profiles;
 using AutoMapper;
-using BlogApp.Application.Tests.Mocks;
+using BlogApp.Tests.Mocks;
 using Shouldly;
 using Moq;
 using BlogApp.Tests.Mocks;

--- a/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.Tests/Comment/Command/UpdateCommentCommandHandlerTest.cs
+++ b/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.Tests/Comment/Command/UpdateCommentCommandHandlerTest.cs
@@ -4,7 +4,7 @@ using BlogApp.Application.Features.Blog.CQRS.Handlers.Commands;
 using BlogApp.Application.Features.Blog.CQRS.Requests.Commands;
 using BlogApp.Application.Profiles;
 using AutoMapper;
-using BlogApp.Application.Tests.Mocks;
+using BlogApp.Tests.Mocks;
 using Shouldly;
 using Moq;
 using Xunit;

--- a/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.Tests/Comment/Query/GetCommentDetailQueryHandlerTest.cs
+++ b/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.Tests/Comment/Query/GetCommentDetailQueryHandlerTest.cs
@@ -3,7 +3,7 @@ using BlogApp.Application.Contracts.Persistence;
 using BlogApp.Application.Features.Comments.CQRS.Handlers;
 using BlogApp.Application.Features.Comments.CQRS.Queries;
 using BlogApp.Application.Profiles;
-using BlogApp.Application.Tests.Mocks;
+using BlogApp.Tests.Mocks;
 using Moq;
 using Shouldly;
 using Xunit;

--- a/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.Tests/Comment/Query/GetCommentListQueryHandlerTest.cs
+++ b/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.Tests/Comment/Query/GetCommentListQueryHandlerTest.cs
@@ -3,7 +3,7 @@ using BlogApp.Application.Contracts.Persistence;
 using BlogApp.Application.Features.Comments.CQRS.Handlers;
 using BlogApp.Application.Features.Comments.CQRS.Queries;
 using BlogApp.Application.Profiles;
-using BlogApp.Application.Tests.Mocks;
+using BlogApp.Tests.Mocks;
 using Moq;
 using Shouldly;
 using Xunit;

--- a/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.Tests/Mocks/MockUnitOfWork.cs
+++ b/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.Tests/Mocks/MockUnitOfWork.cs
@@ -1,6 +1,4 @@
-
 using BlogApp.Application.Contracts.Persistence;
-using BlogApp.Application.Tests.Mocks;
 using Moq;
 using System;
 using System.Collections.Generic;
@@ -9,13 +7,14 @@ using System.Text;
 using System.Threading.Tasks;
 using BlogApp.Tests.Mocks;
 
-namespace BlogApp.Application.Tests.Mocks
+namespace BlogApp.Tests.Mocks
 {
     public static class MockUnitOfWork
     {
         public static Mock<IUnitOfWork> GetUnitOfWork()
         {
             var mockUow = new Mock<IUnitOfWork>();
+            var mockUserRepo = MockUserRepository.GetUserRepository();
             var mockBlogRepo = MockBlogRepository.GetBlogRepository();
             var mockTagRepo = MockTagRepository.GetTagRepository();
             mockUow.Setup(r => r.TagRepository).Returns(mockTagRepo.Object);
@@ -24,6 +23,7 @@ namespace BlogApp.Application.Tests.Mocks
             
             
             var mockCommentRepo = MockCommentRepository.GetCommentRepository();
+            mockUow.Setup(r => r._UserRepository).Returns(mockUserRepo.Object);
             mockUow.Setup(r => r.BlogRepository).Returns(mockBlogRepo.Object);
             mockUow.Setup(r=>r.ReviewRepository).Returns(mockReviewRepo.Object);
             mockUow.Setup(r => r.BlogRateRepository).Returns(mockBlogRateRepo.Object);

--- a/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.Tests/Mocks/MockUserRepository.cs
+++ b/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.Tests/Mocks/MockUserRepository.cs
@@ -1,0 +1,70 @@
+using BlogApp.Application.Contracts.Persistence;
+using Moq;
+
+namespace BlogApp.Tests.Mocks;
+
+public static class MockUserRepository
+{
+    public static Mock<I_UserRepository> GetUserRepository()
+    {
+        var users = new List<BlogApp.Domain.User>
+        {
+            new ()
+            {
+                Id=1,
+                FirstName = "Abebe",
+                LastName = "Kebede",
+                Email = "Abe@gmail.com",
+                AccountId = "abe1"
+                
+            },
+            
+            new ()
+            {
+                Id=2,
+                FirstName = "Alemu",
+                LastName = "bekele",
+                Email = "Alemu@gmail.com",
+                AccountId = "alemu1"
+               
+            }
+        };
+
+        var mockRepo = new Mock<I_UserRepository>();
+
+        mockRepo.Setup(r => r.GetAll()).ReturnsAsync(users);
+        
+        mockRepo.Setup(r => r.Add(It.IsAny<BlogApp.Domain.User>())).ReturnsAsync((BlogApp.Domain.User user) =>
+        {
+            user.Id = users.Count() + 1;
+            users.Add(user);
+            return user; 
+        });
+
+        mockRepo.Setup(r => r.Update(It.IsAny<Domain.User>())).Callback((Domain.User user) =>
+        {
+            var newUsers = users.Where((r) => r.Id != user.Id);
+            users = newUsers.ToList();
+            users.Add(user);
+        });
+        
+        mockRepo.Setup(r => r.Delete(It.IsAny<Domain.User>())).Callback((Domain.User user) =>
+        {
+            if (users.Exists(b => b.Id == user.Id))
+                users.Remove(users.Find(b => b.Id == user.Id)!);
+        });
+
+        mockRepo.Setup(r => r.Exists(It.IsAny<int>())).ReturnsAsync((int id) =>
+        {
+            var user = users.FirstOrDefault((r) => r.Id == id);
+            return user != null;
+        });
+        
+        mockRepo.Setup(r => r.Get(It.IsAny<int>()))!.ReturnsAsync((int id) =>
+        {
+            return users.FirstOrDefault((r) => r.Id == id);
+        });
+
+        return mockRepo;
+    }
+}

--- a/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.Tests/Review/Command/CreateReviewCommandHandlerTest.cs
+++ b/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.Tests/Review/Command/CreateReviewCommandHandlerTest.cs
@@ -9,7 +9,7 @@ using BlogApp.Application.Features.Reviews.CQRS.Handlers.Commands;
 using BlogApp.Application.Features.Reviews.DTOs;
 using BlogApp.Application.Profiles;
 using BlogApp.Application.Responses;
-using BlogApp.Application.Tests.Mocks;
+using BlogApp.Tests.Mocks;
 using Moq;
 using Shouldly;
 using System;

--- a/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.Tests/Review/Command/DeleteReviewCommandHandlerTest.cs
+++ b/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.Tests/Review/Command/DeleteReviewCommandHandlerTest.cs
@@ -6,7 +6,7 @@ using BlogApp.Application.Features.Reviews.CQRS.Commands;
 using BlogApp.Application.Features.Reviews.CQRS.Handlers.Commands;
 using BlogApp.Application.Features.Reviews.DTOs;
 using BlogApp.Application.Profiles;
-using BlogApp.Application.Tests.Mocks;
+using BlogApp.Tests.Mocks;
 using Moq;
 using Shouldly;
 using System;

--- a/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.Tests/Review/Command/UpdateReviewCommandHandlerTest.cs
+++ b/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.Tests/Review/Command/UpdateReviewCommandHandlerTest.cs
@@ -7,7 +7,7 @@ using BlogApp.Application.Features.Reviews.CQRS.Handlers.Commands;
 using BlogApp.Application.Features.Reviews.DTOs;
 using BlogApp.Application.Profiles;
 using BlogApp.Application.Responses;
-using BlogApp.Application.Tests.Mocks;
+using BlogApp.Tests.Mocks;
 using Moq;
 using Shouldly;
 using System;

--- a/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.Tests/Review/Query/GetReviewDetainQueryHandlerTest.cs
+++ b/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.Tests/Review/Query/GetReviewDetainQueryHandlerTest.cs
@@ -7,7 +7,7 @@ using BlogApp.Application.Features.Reviews.CQRS.Handlers.Queries;
 using BlogApp.Application.Features.Reviews.CQRS.Queries;
 using BlogApp.Application.Profiles;
 using BlogApp.Application.Responses;
-using BlogApp.Application.Tests.Mocks;
+using BlogApp.Tests.Mocks;
 using Moq;
 using Shouldly;
 using System;

--- a/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.Tests/Review/Query/GetReviewListQueryHandlerTest.cs
+++ b/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.Tests/Review/Query/GetReviewListQueryHandlerTest.cs
@@ -4,7 +4,7 @@ using BlogApp.Application.Exceptions;
 using BlogApp.Application.Features.Reviews.CQRS.Handlers.Queries;
 using BlogApp.Application.Features.Reviews.CQRS.Queries;
 using BlogApp.Application.Profiles;
-using BlogApp.Application.Tests.Mocks;
+using BlogApp.Tests.Mocks;
 using Moq;
 using Shouldly;
 using System;

--- a/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.Tests/Services/AuthServiceTest.cs
+++ b/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.Tests/Services/AuthServiceTest.cs
@@ -1,0 +1,378 @@
+using System.Security.Claims;
+using BlogApp.Application.Contracts.Identity;
+using BlogApp.Application.Models.Identity;
+using BlogApp.Application.Models.Mail;
+using BlogApp.Application.Responses;
+using BlogApp.Identity.Models;
+using BlogApp.Identity.Services;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.Options;
+using Moq;
+using Xunit;
+
+namespace BlogApp.Identity.UnitTests;
+
+public class AuthServiceTests
+{
+    #region  fields
+    private readonly AuthService _authService;
+    private readonly Mock<UserManager<BlogUser>> _userManagerMock;
+    private readonly Mock<SignInManager<BlogUser>> _signInManagerMock;
+    private readonly Mock<IEmailSender> _emailSenderMock;
+
+    #endregion
+    public AuthServiceTests()
+    {
+        _userManagerMock = new Mock<UserManager<BlogUser>>(Mock.Of<IUserStore<BlogUser>>(), null, null, null, null, null, null, null, null);
+        _signInManagerMock = new Mock<SignInManager<BlogUser>>(_userManagerMock.Object, Mock.Of<IHttpContextAccessor>(), Mock.Of<IUserClaimsPrincipalFactory<BlogUser>>(), null, null, null, null);
+        _emailSenderMock = new Mock<IEmailSender>();
+
+        var jwtOptions =  Options.Create(new JwtSettings() 
+        { 
+            Key = "2J9JFA9THQTH9AHRHTQ9YAQTJ",
+            Issuer = "BlogApi",
+            Audience = "BlogApiUser",
+            DurationInMinutes = 60
+        });
+
+        _authService = new AuthService(_userManagerMock.Object, _signInManagerMock.Object, jwtOptions, _emailSenderMock.Object);
+    }
+
+    #region  Login tests
+    [Fact]
+    public async Task Login_ShouldReturnAuthResponse_WhenValidCredentialsProvided()
+    {
+        // Arrange
+        var email = "user@example.com";
+        var password = "Pa$$w0rd";
+        var user = new BlogUser { Email = email, UserName = email };
+        var authRequest = new LoginModel { Email = email, Password = password };
+
+        _userManagerMock.Setup(u => u.FindByEmailAsync(email))
+            .ReturnsAsync(user);
+        _userManagerMock.Setup(u => u.GetClaimsAsync(user))
+            .ReturnsAsync(new List<Claim>());
+        _userManagerMock.Setup(u => u.GetRolesAsync(user))
+            .ReturnsAsync(new List<string>());
+        _signInManagerMock.Setup(s => s.PasswordSignInAsync(user.UserName, password, false, false))
+            .ReturnsAsync(SignInResult.Success);
+
+        // Act
+        var result = await _authService.Login(authRequest);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal(result.Success, true);
+        Assert.NotNull(result.Value);
+        Assert.Equal(user.Email, result.Value.Email);
+        Assert.Equal(user.UserName, result.Value.UserName);
+    }
+
+    [Fact]
+    public async Task Login_ShouldReturnFalse_WhenUserNotFound()
+    {
+        // Arrange
+        var email = "user@example.com";
+        var password = "Pa$$w0rd";
+        var authRequest = new LoginModel { Email = email, Password = password };
+
+        _userManagerMock.Setup(u => u.FindByEmailAsync(email))
+            .ReturnsAsync((BlogUser)null);
+
+        // Act & Assert
+        var result = await _authService.Login(authRequest);
+
+        Assert.NotNull(result);
+        Assert.Equal(result.Success, false);
+        Assert.Equal(result.Value, null);
+
+    }
+
+    [Fact]
+    public async Task Login_ShouldReturnFalse_WhenInvalidCredentialsProvided()
+    {
+        // Arrange
+        var email = "user@example.com";
+        var password = "Pa$$w0rd";
+        var user = new BlogUser { Email = email, UserName = email };
+        var authRequest = new LoginModel { Email = email, Password = password };
+
+        _userManagerMock.Setup(u => u.FindByEmailAsync(email))
+            .ReturnsAsync(user);
+        _signInManagerMock.Setup(s => s.PasswordSignInAsync(user.UserName, password, false, false))
+            .ReturnsAsync(SignInResult.Failed);
+
+        // Act & Assert
+        var result = await _authService.Login(authRequest);
+
+        Assert.NotNull(result);
+        Assert.Equal(result.Success, false);
+        Assert.Equal(result.Value, null);
+
+    }
+
+    #endregion
+
+
+    #region Register tests
+    [Fact]
+    public async Task Register_ShouldReturnFalse_WhenExistingEmailFound()
+    {
+        // Arrange
+        var request = new RegistrationModel
+        {
+            Email = "test@example.com",
+            Password = "P@ssw0rd",
+            UserName = "johndoe",
+            Roles = new List<string>{"User"}
+        };
+
+        _userManagerMock
+            .SetupSequence(x => x.FindByNameAsync(request.UserName))
+            .ReturnsAsync(new BlogUser());
+
+        _userManagerMock
+            .Setup(x => x.FindByEmailAsync(request.Email))
+            .ReturnsAsync(new BlogUser());
+
+        // Act & Assert
+        var result = await _authService.Register(request);
+
+        Assert.NotNull(result);
+        Assert.Equal(result.Success, false);
+        Assert.Equal(result.Value, null);
+    }
+
+    [Fact]
+    public async Task Register_ShouldReturnRegistrationResponse_WhenUserCreatedSuccessfully()
+    {
+        // Arrange
+        var request = new RegistrationModel
+        {
+            Email = "test@example.com",
+            Password = "P@ssw0rd",
+            UserName = "johndoe",
+            Roles = new List<string>{"User"}
+        };
+
+        var emailResult = new Result<Email>()
+        {
+            Success = true
+        };
+
+        _emailSenderMock.Setup(u => u.sendEmail(It.IsAny<Email>()))
+            .ReturnsAsync(emailResult);
+
+        _userManagerMock
+            .SetupSequence(x => x.FindByEmailAsync(request.Email))
+            .ReturnsAsync((BlogUser)null);
+
+        _userManagerMock
+            .SetupSequence(x => x.FindByNameAsync(request.UserName))
+            .ReturnsAsync(new BlogUser());
+
+        _userManagerMock
+            .SetupSequence(x => x.GenerateEmailConfirmationTokenAsync(It.IsAny<BlogUser>()))
+            .ReturnsAsync("token");
+
+        _userManagerMock
+            .Setup(x => x.CreateAsync(It.IsAny<BlogUser>(), request.Password))
+            .ReturnsAsync(IdentityResult.Success);
+
+        _userManagerMock
+            .Setup(x => x.AddToRoleAsync(It.IsAny<BlogUser>(), "User"))
+            .ReturnsAsync(IdentityResult.Success);
+
+        // Act
+        var result = await _authService.Register(request);
+
+        Assert.NotNull(result);
+        Assert.Equal(result.Success, true);
+        Assert.NotNull(result.Value);
+
+    }
+
+    #endregion
+
+
+    #region  ForgotPassword tests
+    [Fact]
+    public async Task ForgotPassword_ShouldReturnTrue_WhenUserFoundAndHasConfirmedEmail()
+    {
+        // Arrange
+        var email = "user@example.com";
+        var user = new BlogUser 
+        { 
+            Email = email, 
+            UserName = email,
+            EmailConfirmed = true
+        };
+        var expectedToken = "TOKEN123";
+
+        var emailResult = new Result<Email>()
+        {
+            Success = true
+        };
+
+        _userManagerMock.Setup(u => u.FindByEmailAsync(email))
+            .ReturnsAsync(user);
+        _userManagerMock.Setup(u => u.GeneratePasswordResetTokenAsync(user))
+            .ReturnsAsync(expectedToken);
+        _emailSenderMock.Setup(u => u.sendEmail(It.IsAny<Email>()))
+            .ReturnsAsync(emailResult);
+
+        // Act
+        var result = await _authService.ForgotPassword(email);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal(result.Success, true);
+        Assert.Equal(result.Value, email);
+    }
+
+    [Fact]
+    public async Task ForgotPassword_ShouldReturnFalse_WhenUserNotFound()
+    {
+        // Arrange
+        var email = "user@example.com";
+
+        _userManagerMock.Setup(u => u.FindByEmailAsync(email))
+            .ReturnsAsync((BlogUser)null);
+
+        // Act
+        var result = await _authService.ForgotPassword(email);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal(result.Success, false);
+        Assert.Equal(result.Value, null);
+        
+    }
+
+    public async Task ForgotPassword_ShouldReturnFalse_WhenEmailNotConfirmed()
+    {
+        // Arrange
+        var email = "user@example.com";
+        var user = new BlogUser 
+        { 
+            Email = email, 
+            UserName = email,
+            EmailConfirmed = false
+        };
+
+        _userManagerMock.Setup(u => u.FindByEmailAsync(email))
+            .ReturnsAsync(user);
+
+        // Act
+        var result = await _authService.ForgotPassword(email);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal(result.Success, false);
+        Assert.Equal(result.Value, null);
+        
+    }
+
+    #endregion
+
+
+    #region  ResetPassword tests
+    [Fact]
+    public async Task ResetPassword_ShouldReturnTrue_WhenValidTokenAndNewPasswordProvided()
+    {
+        // Arrange
+        var email = "user@example.com";
+        var token = "TOKEN123";
+        var newPassword = "newP@ssw0rd";
+        var user = new BlogUser { Email = email, UserName = email };
+
+        _userManagerMock.Setup(u => u.FindByEmailAsync(email))
+            .ReturnsAsync(user);
+        _userManagerMock.Setup(u => u.ResetPasswordAsync(user, token, newPassword))
+            .ReturnsAsync(IdentityResult.Success);
+
+        var resetModel = new ResetPasswordModel()
+        {
+            Email = email,
+            Token = token,
+            Password = newPassword
+        };
+
+        // Act
+        var result = await _authService.ResetPassword(resetModel);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal(result.Success, true);
+        Assert.Equal(result.Value, email);
+    }
+
+    [Fact]
+    public async Task ResetPassword_ShouldReturnFalse_WhenUserNotFound()
+    {
+        // Arrange
+        var email = "user@example.com";
+        var token = "TOKEN123";
+        var newPassword = "newP@ssw0rd";
+
+        _userManagerMock.Setup(u => u.FindByEmailAsync(email))
+            .ReturnsAsync((BlogUser)null);
+
+        var resetModel = new ResetPasswordModel()
+        {
+            Email = email,
+            Token = token,
+            Password = newPassword
+        };
+
+        // Act
+        var result = await _authService.ResetPassword(resetModel);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal(result.Success, false);
+        Assert.Equal(result.Value, null);
+    }
+
+    [Fact]
+    public async Task ResetPassword_ShouldReturnFalse_WhenInvalidTokenProvided()
+    {
+        // Arrange
+        var email = "user@example.com";
+        var user = new BlogUser { Email = email, UserName = email };
+        var token = "TOKEN123";
+        var newPassword = "newP@ssw0rd";
+
+        var identityResult = IdentityResult.Failed(new IdentityError 
+            { 
+                Description = "Invalid Token." 
+            });
+
+
+        _userManagerMock.Setup(u => u.FindByEmailAsync(email))
+            .ReturnsAsync(user);
+        _userManagerMock.Setup(u => u.ResetPasswordAsync(user, token, newPassword))
+            .ReturnsAsync(identityResult);
+
+        var resetModel = new ResetPasswordModel()
+        {
+            Email = email,
+            Token = token,
+            Password = newPassword
+        };
+
+        // Act
+        var result = await _authService.ResetPassword(resetModel);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal(result.Success, false);
+        Assert.Equal(result.Value, null);
+
+    }
+
+    #endregion
+
+}
+

--- a/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.Tests/Tags/Command/CreateTagCommandHandlerTest.cs
+++ b/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.Tests/Tags/Command/CreateTagCommandHandlerTest.cs
@@ -4,7 +4,7 @@ using BlogApp.Application.Features.Tags.CQRS.Commands;
 using BlogApp.Application.Features.Tags.CQRS.Handlers;
 using BlogApp.Application.Profiles;
 using AutoMapper;
-using BlogApp.Application.Tests.Mocks;
+using BlogApp.Tests.Mocks;
 using Shouldly;
 using Moq;
 using Xunit;

--- a/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.Tests/Tags/Command/DeleteTagCommandHandlerTest.cs
+++ b/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.Tests/Tags/Command/DeleteTagCommandHandlerTest.cs
@@ -4,7 +4,7 @@ using BlogApp.Application.Features.Tags.DTOs;
 using BlogApp.Application.Features.Tags.CQRS.Commands;
 using BlogApp.Application.Profiles;
 using AutoMapper;
-using BlogApp.Application.Tests.Mocks;
+using BlogApp.Tests.Mocks;
 using Shouldly;
 using Moq;
 using BlogApp.Tests.Mocks;

--- a/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.Tests/Tags/Command/UpdateTagCommandHandlerTest.cs
+++ b/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.Tests/Tags/Command/UpdateTagCommandHandlerTest.cs
@@ -4,7 +4,7 @@ using BlogApp.Application.Features.Tags.CQRS.Commands;
 using BlogApp.Application.Features.Tags.CQRS.Handlers;
 using BlogApp.Application.Profiles;
 using AutoMapper;
-using BlogApp.Application.Tests.Mocks;
+using BlogApp.Tests.Mocks;
 using Shouldly;
 using Moq;
 using Xunit;

--- a/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.Tests/Tags/Query/GetTagDetailsQuery.cs
+++ b/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.Tests/Tags/Query/GetTagDetailsQuery.cs
@@ -3,7 +3,7 @@ using BlogApp.Application.Features.Tags.CQRS.Handlers;
 using BlogApp.Application.Features.Tags.CQRS.Queries;
 using BlogApp.Application.Profiles;
 using AutoMapper;
-using BlogApp.Application.Tests.Mocks;
+using BlogApp.Tests.Mocks;
 using Shouldly;
 using Moq;
 using BlogApp.Tests.Mocks;

--- a/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.Tests/Tags/Query/GetTagListQueryTest.cs
+++ b/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.Tests/Tags/Query/GetTagListQueryTest.cs
@@ -3,7 +3,7 @@ using BlogApp.Application.Features.Tags.CQRS.Handlers;
 using BlogApp.Application.Features.Tags.CQRS.Queries;
 using BlogApp.Application.Profiles;
 using AutoMapper;
-using BlogApp.Application.Tests.Mocks;
+using BlogApp.Tests.Mocks;
 using Shouldly;
 using Moq;
 using BlogApp.Tests.Mocks;

--- a/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.Tests/Users/Command/Create_UserCommandHandlerTests.cs
+++ b/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.Tests/Users/Command/Create_UserCommandHandlerTests.cs
@@ -1,0 +1,90 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using AutoMapper;
+using BlogApp.Application.Contracts.Persistence;
+using BlogApp.Application.Features.Users.CQRS.Commands;
+using BlogApp.Application.Features.Users.CQRS.Handlers;
+using BlogApp.Application.Features.Users.DTOs;
+using BlogApp.Application.Features.Users.DTOs.Validators;
+using BlogApp.Application.Responses;
+using BlogApp.Application.Profiles;
+using BlogApp.Tests.Mocks;
+using BlogApp.Domain;
+using FluentAssertions;
+using Moq;
+using Shouldly;
+using Xunit;
+
+namespace BlogApp.Tests.Users.Command
+{
+     public class Create_UserCommandHandlerTests
+    {
+        private readonly IMapper _mapper;
+        private readonly Mock<IUnitOfWork> _mockUow;
+        private readonly Create_UserDto _userDto;
+        private readonly Create_UserDto _invalidUserDto;
+
+        private readonly Create_UserCommandHandler _handler;
+
+        public Create_UserCommandHandlerTests()
+        {
+            _mockUow = MockUnitOfWork.GetUnitOfWork();
+            
+            var mapperConfig = new MapperConfiguration(c => 
+            {
+                c.AddProfile<MappingProfile>();
+            });
+
+            _mapper = mapperConfig.CreateMapper();
+            _handler = new Create_UserCommandHandler(_mockUow.Object, _mapper);
+
+            _userDto = new Create_UserDto
+            {
+                AccountId = "1",
+                FirstName = "John",
+                LastName = "Doe",
+                Email = "johndoe@example.com",
+                Password = "password"
+            };
+
+            _invalidUserDto = new Create_UserDto
+            {
+                AccountId = "2",
+                FirstName = "",
+                LastName = "Doe",
+                Email = "johndoe@example.com",
+                Password = "password"
+            };
+        }
+
+        [Fact]
+        public async Task Valid_User_Added()
+        {
+            var result = await _handler.Handle(new Create_UserCommand() { Create_UserDto = _userDto }, CancellationToken.None);
+
+            var users = await _mockUow.Object._UserRepository.GetAll();
+
+            result.ShouldBeOfType<BaseCommandResponse>();
+
+            users.Count.ShouldBe(3);
+        }
+
+        [Fact]
+        public async Task InValid_User_Added()
+        {
+
+            var result = await _handler.Handle(new Create_UserCommand() { Create_UserDto = _invalidUserDto}, CancellationToken.None);
+
+            var users = await _mockUow.Object._UserRepository.GetAll();
+            
+            users.Count.ShouldBe(2);
+
+            result.ShouldBeOfType<BaseCommandResponse>();
+            
+        }
+    }
+}

--- a/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.Tests/Users/Command/Delete_UserCommandHandlerTests.cs
+++ b/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.Tests/Users/Command/Delete_UserCommandHandlerTests.cs
@@ -1,0 +1,68 @@
+using System.Threading;
+using System.Threading.Tasks;
+using AutoMapper;
+using BlogApp.Application.Contracts.Persistence;
+using BlogApp.Application.Exceptions;
+using BlogApp.Application.Features.Users.CQRS.Commands;
+using BlogApp.Application.Features.Users.CQRS.Handlers;
+using BlogApp.Application.Profiles;
+using BlogApp.Tests.Mocks;
+using Moq;
+using Shouldly;
+using Xunit;
+
+namespace BlogApp.Tests.Users.Command
+{
+    public class Delete_UserCommandHandlerTests
+    {
+        private IMapper _mapper;
+        private Mock<IUnitOfWork> _mockUnitOfWork;
+        private Delete_UserCommandHandler _handler;
+
+        public Delete_UserCommandHandlerTests()
+        {
+            _mockUnitOfWork = MockUnitOfWork.GetUnitOfWork();
+
+            _mapper = new MapperConfiguration(c =>
+            {
+                c.AddProfile<MappingProfile>();
+            }).CreateMapper();
+
+            _handler = new Delete_UserCommandHandler(_mockUnitOfWork.Object, _mapper);
+        }
+
+        [Fact]
+        public async Task DeleteUserValid()
+        {
+            // Arrange
+            var user = new Domain.User
+            {
+                Id = 1,
+                FirstName = "John",
+                LastName = "Doe",
+                Email = "johndoe@example.com",
+                Password = "password"
+            };
+
+            _mockUnitOfWork.Setup(x => x._UserRepository.Get(user.Id)).ReturnsAsync(user);
+
+            // Act
+            await _handler.Handle(new Delete_UserCommand() { Id = user.Id }, CancellationToken.None);
+
+            // Assert
+            _mockUnitOfWork.Verify(x => x._UserRepository.Delete(user), Times.Once);
+            _mockUnitOfWork.Verify(x => x.Save(), Times.Once);
+        }
+
+        [Fact]
+        public async Task DeleteUserInvalid()
+        {
+            // Arrange
+            _mockUnitOfWork.Setup(x => x._UserRepository.Get(999)).ReturnsAsync((Domain.User)null);
+
+            // Assert
+            await Assert.ThrowsAsync<NotFoundException>(() =>
+                _handler.Handle(new Delete_UserCommand() { Id = 999 }, CancellationToken.None));
+        }
+    }
+}

--- a/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.Tests/Users/Command/Update_UserCommandHandlerTests.cs
+++ b/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.Tests/Users/Command/Update_UserCommandHandlerTests.cs
@@ -1,0 +1,102 @@
+using System.Threading;
+using System.Threading.Tasks;
+using AutoMapper;
+using BlogApp.Application.Contracts.Persistence;
+using BlogApp.Application.Exceptions;
+using BlogApp.Application.Features.Users.CQRS.Commands;
+using BlogApp.Application.Features.Users.DTOs.Validators;
+using BlogApp.Application.Features.Users.DTOs;
+using BlogApp.Application.Features.Users.CQRS.Handlers;
+using BlogApp.Domain;
+using FluentAssertions;
+using MediatR;
+using Moq;
+using Xunit;
+
+
+namespace BlogApp.Tests.Users.Command
+{
+    public class Update_UserCommandHandlerTests
+    {
+        private readonly IMapper _mapper;
+        private readonly Mock<IUnitOfWork> _mockUnitOfWork;
+        private readonly Update_UserCommandHandler _handler;
+
+        public Update_UserCommandHandlerTests()
+        {
+            var mapperConfig = new MapperConfiguration(cfg =>
+            {
+                cfg.CreateMap<Update_UserDto, User>();
+            });
+
+            _mapper = mapperConfig.CreateMapper();
+            _mockUnitOfWork = new Mock<IUnitOfWork>();
+            _handler = new Update_UserCommandHandler(_mockUnitOfWork.Object, _mapper);
+        }
+
+        [Fact]
+        public async Task UpdateUserCommandHandler_WhenUserExists_ShouldUpdateUser()
+        {
+            // Arrange
+            var existingUserId = 1;
+            var existingUser = new User
+            {
+                Id = existingUserId,
+                FirstName = "John",
+                LastName = "Doe",
+                Email = "johndoe@example.com",
+                Password = "password"
+            };
+            var updateDto = new Update_UserDto
+            {
+                Id = existingUserId,
+                FirstName = "Jane",
+                LastName = "Doe",
+                Email = "janedoe@example.com",
+                Password = "newpassword"
+            };
+             var command = new Update_UserCommand()
+                        {
+                        Update_UserDto = updateDto
+                        };
+            _mockUnitOfWork.Setup(uow => uow._UserRepository.Get(existingUserId))
+                .ReturnsAsync(existingUser);
+
+            // Act
+            await _handler.Handle(command, CancellationToken.None);
+
+            // Assert
+            _mockUnitOfWork.Verify(uow => uow._UserRepository.Update(It.IsAny<User>()), Times.Once);
+            _mockUnitOfWork.Verify(uow => uow.Save(), Times.Once);
+            existingUser.FirstName.Should().Be(updateDto.FirstName);
+            existingUser.LastName.Should().Be(updateDto.LastName);
+            existingUser.Email.Should().Be(updateDto.Email);
+            existingUser.Password.Should().Be(updateDto.Password);
+        }
+
+        [Fact]
+        public async Task UpdateUserCommandHandler_WhenUserDoesNotExist_ShouldThrowNotFoundException()
+        {
+            // Arrange
+            var nonExistingUserId = 1;
+            var updateDto = new Update_UserDto
+            {
+                Id = nonExistingUserId,
+                FirstName = "Jane",
+                LastName = "Doe",
+                Email = "janedoe@example.com",
+                Password = "newpassword"
+            };
+          var command = new Update_UserCommand()
+                        {
+                            Update_UserDto = updateDto
+                        };
+            _mockUnitOfWork.Setup(uow => uow._UserRepository.Get(nonExistingUserId))
+                .ReturnsAsync(() => null);
+
+            // Act & Assert
+            await Assert.ThrowsAsync<NotFoundException>(() => _handler.Handle(command, CancellationToken.None));
+        }
+    }
+}
+

--- a/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.Tests/Users/Query/Get_UserDetailQueryHandlerTests.cs
+++ b/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.Tests/Users/Query/Get_UserDetailQueryHandlerTests.cs
@@ -1,0 +1,46 @@
+using AutoMapper;
+using BlogApp.Application.Contracts.Persistence;
+using BlogApp.Application.Features.Users.CQRS.Handlers;
+using BlogApp.Application.Features.Users.CQRS.Queries;
+using BlogApp.Application.Features.Users.DTOs;
+using BlogApp.Domain;
+using Moq;
+using System.Threading;
+using Xunit;
+
+namespace BlogApp.Tests.Users.Query
+{
+    public class Get_UserDetailQueryHandlerTests
+    {
+        private readonly Mock<IUnitOfWork> _mockUnitOfWork;
+        private readonly Mock<IMapper> _mockMapper;
+
+        public Get_UserDetailQueryHandlerTests()
+        {
+            _mockUnitOfWork = new Mock<IUnitOfWork>();
+            _mockMapper = new Mock<IMapper>();
+        }
+
+        [Fact]
+        public async void Handle_WithValidQuery_ShouldReturnUserDto()
+        {
+            // Arrange
+            var userId = 1;
+            var user = new User { Id = userId, FirstName = "John", LastName = "Doe", Email = "johndoe@example.com" };
+            var expectedUserDto = new _UserDto { Id = userId, FirstName = "John", LastName = "Doe", Email = "johndoe@example.com" };
+            var query = new Get_UserDetailQuery { Id = userId };
+            var cancellationToken = new CancellationToken();
+
+            _mockUnitOfWork.Setup(uow => uow._UserRepository.Get(userId)).ReturnsAsync(user);
+            _mockMapper.Setup(m => m.Map<_UserDto>(user)).Returns(expectedUserDto);
+
+            var handler = new Get_UserDetailQueryHandler(_mockUnitOfWork.Object, _mockMapper.Object);
+
+            // Act
+            var result = await handler.Handle(query, cancellationToken);
+
+            // Assert
+            Assert.Equal(expectedUserDto, result);
+        }
+    }
+}

--- a/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.Tests/Users/Query/Get_UserListQueryHandlerTests.cs
+++ b/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp.Tests/Users/Query/Get_UserListQueryHandlerTests.cs
@@ -1,0 +1,88 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using AutoMapper;
+using BlogApp.Application.Contracts.Persistence;
+using BlogApp.Application.Features.Users.CQRS.Handlers;
+using BlogApp.Application.Features.Users.CQRS.Queries;
+using BlogApp.Application.Features.Users.DTOs;
+using BlogApp.Domain;
+using Moq;
+using Xunit;
+
+namespace BlogApp.Tests.Users.Query
+{
+    public class Get_UserListQueryHandlerTests
+    {
+        private readonly Mock<IUnitOfWork> _mockUnitOfWork;
+        private readonly Mock<IMapper> _mockMapper;
+
+        public Get_UserListQueryHandlerTests()
+        {
+            _mockUnitOfWork = new Mock<IUnitOfWork>();
+            _mockMapper = new Mock<IMapper>();
+        }
+
+        [Fact]
+        public async Task Handle_ReturnsListOfUserDtos_WhenUsersExist()
+        {
+            // Arrange
+            var users = new List<User>
+            {
+                new User { Id = 1, FirstName = "John", LastName = "Doe", Email = "johndoe@mail.com" },
+                new User { Id = 2, FirstName = "Jane", LastName = "Doe", Email = "janedoe@mail.com" },
+                new User { Id = 3, FirstName = "Bob", LastName = "Smith", Email = "bobsmith@mail.com" }
+            };
+
+            var userDtos = new List<_UserDto>
+            {
+                new _UserDto { Id = 1, FirstName = "John", LastName = "Doe", Email = "johndoe@mail.com" },
+                new _UserDto { Id = 2, FirstName = "Jane", LastName = "Doe", Email = "janedoe@mail.com" },
+                new _UserDto { Id = 3, FirstName = "Bob", LastName = "Smith", Email = "bobsmith@mail.com" }
+            };
+
+            _mockUnitOfWork.Setup(u => u._UserRepository.GetAll()).ReturnsAsync(users);
+            _mockMapper.Setup(m => m.Map<List<_UserDto>>(users)).Returns(userDtos);
+
+            var handler = new Get_UserListQueryHandler(_mockUnitOfWork.Object, _mockMapper.Object);
+
+            // Act
+            var result = await handler.Handle(new Get_UserListQuery(), CancellationToken.None);
+
+            // Assert
+            Assert.NotNull(result);
+            Assert.IsType<List<_UserDto>>(result);
+            Assert.Equal(userDtos.Count, result.Count);
+
+            for (int i = 0; i < userDtos.Count; i++)
+            {
+                Assert.Equal(userDtos[i].Id, result[i].Id);
+                Assert.Equal(userDtos[i].FirstName, result[i].FirstName);
+                Assert.Equal(userDtos[i].LastName, result[i].LastName);
+                Assert.Equal(userDtos[i].Email, result[i].Email);
+            }
+        }
+
+        [Fact]
+        public async Task Handle_ReturnsEmptyList_WhenNoUsersExist()
+        {
+            // Arrange
+            var users = new List<User>();
+            var userDtos = new List<_UserDto>();
+
+            _mockUnitOfWork.Setup(u => u._UserRepository.GetAll()).ReturnsAsync(users);
+            _mockMapper.Setup(m => m.Map<List<_UserDto>>(users)).Returns(userDtos);
+
+            var handler = new Get_UserListQueryHandler(_mockUnitOfWork.Object, _mockMapper.Object);
+
+            // Act
+            var result = await handler.Handle(new Get_UserListQuery(), CancellationToken.None);
+
+            // Assert
+            Assert.NotNull(result);
+            Assert.IsType<List<_UserDto>>(result);
+            Assert.Empty(result);
+        }
+    }
+}

--- a/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp3.sln
+++ b/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp3.sln
@@ -1,4 +1,4 @@
-
+﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.5.33516.290
@@ -16,6 +16,10 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BlogApp.Tests", "BlogApp.Tests\BlogApp.Tests.csproj", "{48504969-31F6-44E1-BF83-381DF43CAE3A}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BlogApp.Identity", "BlogApp.Identity\BlogApp.Identity.csproj", "{A71E8E03-901D-4276-BCE6-BFC60255879E}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BlogApp.Infrastructure", "BlogApp.Infrastructure\BlogApp.Infrastructure.csproj", "{5175CF0A-102B-4D12-A72C-C9B7AE6C38C4}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BlogApp.Tests", "BlogApp.Tests\BlogApp.Tests.csproj", "{B4EE32AA-B84A-4424-8F87-094CFDEDE91D}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -47,11 +51,21 @@ Global
 		{A71E8E03-901D-4276-BCE6-BFC60255879E}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{A71E8E03-901D-4276-BCE6-BFC60255879E}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{A71E8E03-901D-4276-BCE6-BFC60255879E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5175CF0A-102B-4D12-A72C-C9B7AE6C38C4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5175CF0A-102B-4D12-A72C-C9B7AE6C38C4}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5175CF0A-102B-4D12-A72C-C9B7AE6C38C4}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5175CF0A-102B-4D12-A72C-C9B7AE6C38C4}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B4EE32AA-B84A-4424-8F87-094CFDEDE91D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B4EE32AA-B84A-4424-8F87-094CFDEDE91D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B4EE32AA-B84A-4424-8F87-094CFDEDE91D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B4EE32AA-B84A-4424-8F87-094CFDEDE91D}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
+		{48504969-31F6-44E1-BF83-381DF43CAE3A} = {6253B6ED-75AA-4707-AF62-F371112A0C3B}
+		{5175CF0A-102B-4D12-A72C-C9B7AE6C38C4} = {6253B6ED-75AA-4707-AF62-F371112A0C3B}
 		{A71E8E03-901D-4276-BCE6-BFC60255879E} = {6253B6ED-75AA-4707-AF62-F371112A0C3B}
 		{686C7BE8-977D-4D10-B66B-B740DEA007A0} = {6253B6ED-75AA-4707-AF62-F371112A0C3B}
 		{A1167253-13B6-4202-AA21-3BFB60BF9D4B} = {6253B6ED-75AA-4707-AF62-F371112A0C3B}

--- a/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp3.sln
+++ b/Backend/starter_project_zsilentcoders/BlogApp3/BlogApp3.sln
@@ -15,6 +15,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BlogApp.API", "BlogApp.API\
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BlogApp.Tests", "BlogApp.Tests\BlogApp.Tests.csproj", "{48504969-31F6-44E1-BF83-381DF43CAE3A}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BlogApp.Identity", "BlogApp.Identity\BlogApp.Identity.csproj", "{A71E8E03-901D-4276-BCE6-BFC60255879E}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -41,11 +43,16 @@ Global
 		{48504969-31F6-44E1-BF83-381DF43CAE3A}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{48504969-31F6-44E1-BF83-381DF43CAE3A}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{48504969-31F6-44E1-BF83-381DF43CAE3A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A71E8E03-901D-4276-BCE6-BFC60255879E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A71E8E03-901D-4276-BCE6-BFC60255879E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A71E8E03-901D-4276-BCE6-BFC60255879E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A71E8E03-901D-4276-BCE6-BFC60255879E}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
+		{A71E8E03-901D-4276-BCE6-BFC60255879E} = {6253B6ED-75AA-4707-AF62-F371112A0C3B}
 		{686C7BE8-977D-4D10-B66B-B740DEA007A0} = {6253B6ED-75AA-4707-AF62-F371112A0C3B}
 		{A1167253-13B6-4202-AA21-3BFB60BF9D4B} = {6253B6ED-75AA-4707-AF62-F371112A0C3B}
 		{4590EDE4-0F3A-4CCC-951F-C1B937591D34} = {6253B6ED-75AA-4707-AF62-F371112A0C3B}


### PR DESCRIPTION
This pull request updates the user authentication process in the backend project by implementing JSON Web Token (JWT) based authentication.

In this update, we have added a new authentication middleware that verifies the JWT token and grants access to the authorized user. The JWT token is generated at the time of user login and is then used to authenticate the user for subsequent requests. The token contains user information and is signed using a secret key to ensure its authenticity.

We use a separate Identity database for the login service which is provided by Identity framework. We used it in conjuction with MailKit to send emails for password reset and confirming emails. And we used google smtp server with our personal account to send the emails.

We also implemented a separate user model so that during integration phase it can easily be integrated with other models, since it is on the same database. And we linked this user to the identity user by including a field called AccountId which refers to the identity user on the identity database.

we will remove the delete and create actions on the user controller and the delete action in the authcontroller, as they are only there for testing purposes and shouldn't be on the production version.