### PR TITLE
fix(web-iconics): change pagination props to reduce redundant calculations

### DIFF
--- a/Web/starter_project_iconics/components/common/Pagination.tsx
+++ b/Web/starter_project_iconics/components/common/Pagination.tsx
@@ -1,12 +1,23 @@
+import { useEffect } from "react"
+
 interface PaginationProps{
-    pagesCount: number
+    totalItems: number
+    itemsPerPage: number
     currentPage: number
     setCurrentPage: (page: number) => void
+    setStartIndex: (index: number) => void
+    setEndIndex: (index: number) => void
 }
 
-const Pagination : React.FC<PaginationProps> = ({pagesCount, currentPage, setCurrentPage}) => {
+const Pagination : React.FC<PaginationProps> = ({totalItems, itemsPerPage, currentPage, setCurrentPage, setStartIndex, setEndIndex}) => {
+  const pagesCount = Math.ceil(totalItems/itemsPerPage)
   let pages: JSX.Element[] = []
   const visible = 2
+  
+  useEffect(()=>{
+    setStartIndex((currentPage-1)*itemsPerPage)
+    setEndIndex((currentPage-1)*itemsPerPage+itemsPerPage)
+  }, [currentPage])
 
   for (let page:number = 1; page <= pagesCount; page++) {
     

--- a/Web/starter_project_iconics/components/common/Pagination.tsx
+++ b/Web/starter_project_iconics/components/common/Pagination.tsx
@@ -17,7 +17,7 @@ const Pagination : React.FC<PaginationProps> = ({totalItems, itemsPerPage, curre
   useEffect(()=>{
     setStartIndex((currentPage-1)*itemsPerPage)
     setEndIndex((currentPage-1)*itemsPerPage+itemsPerPage)
-  }, [currentPage])
+  }, [currentPage, itemsPerPage, setEndIndex, setStartIndex])
 
   for (let page:number = 1; page <= pagesCount; page++) {
     


### PR DESCRIPTION
add setStart and end index so that the pagination component can automatically calculate the range of items we should display in the current page
