### PR TITLE
feat(backend-dotnetforces7): Add user blog relation

### DIFF
--- a/Backend/starter_project_dotnetforce7/BlogApp2/BlogApp.API/Controllers/BlogsController.cs
+++ b/Backend/starter_project_dotnetforce7/BlogApp2/BlogApp.API/Controllers/BlogsController.cs
@@ -5,6 +5,9 @@ using MediatR;
 using Microsoft.AspNetCore.Mvc;
 using BlogApp.Application.Features.Blogs.CQRS.Commands;
 using API.Controllers;
+using System.Security.Claims;
+using BlogApp.Application.Constants;
+using Microsoft.AspNetCore.Authorization;
 
 namespace BlogApp.Api.Controllers
 {
@@ -34,8 +37,11 @@ namespace BlogApp.Api.Controllers
         }
 
         [HttpPost]
+        [Authorize]
         public async Task<IActionResult> Post([FromBody] CreateBlogDto createBlog)
         {
+            var currentUser = HttpContext.User;
+            createBlog.CreatorId = currentUser.FindFirst(CustomClaimTypes.BlogUserId)?.Value;
             var command = new CreateBlogCommand { BlogDto = createBlog };
             return  HandleResult(await _mediator.Send(command));
         }

--- a/Backend/starter_project_dotnetforce7/BlogApp2/BlogApp.API/appsettings.json
+++ b/Backend/starter_project_dotnetforce7/BlogApp2/BlogApp.API/appsettings.json
@@ -1,6 +1,6 @@
 {
   "ConnectionStrings": {
-    "BlogAppConnectionString": "User ID=intern;Password=intern;Server=localhost;Port=5432;Database=Blog_New;Integrated Security=true;Pooling=true;"
+    "BlogAppConnectionString": "User ID=intern;Password=intern;Server=localhost;Port=5432;Database=twoUser;Integrated Security=true;Pooling=true;Include Error Detail=true;"
   },
   "Logging": {
     "LogLevel": {

--- a/Backend/starter_project_dotnetforce7/BlogApp2/BlogApp.Application/BlogApp.Application.csproj
+++ b/Backend/starter_project_dotnetforce7/BlogApp2/BlogApp.Application/BlogApp.Application.csproj
@@ -17,17 +17,13 @@
     <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="12.0.1" />
     <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="11.5.2" />
     <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="11.1.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity" Version="2.2.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="6.0.15" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="7.0.5" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\BlogApp.Domain\BlogApp.Domain.csproj" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Reference Include="Microsoft.Extensions.Identity.Core">
-      <HintPath>..\..\..\..\..\..\..\usr\local\share\dotnet\shared\Microsoft.AspNetCore.App\6.0.16\Microsoft.Extensions.Identity.Core.dll</HintPath>
-    </Reference>
   </ItemGroup>
 
 </Project>

--- a/Backend/starter_project_dotnetforce7/BlogApp2/BlogApp.Application/Constants/CustomClaimTypes.cs
+++ b/Backend/starter_project_dotnetforce7/BlogApp2/BlogApp.Application/Constants/CustomClaimTypes.cs
@@ -7,5 +7,6 @@ namespace BlogApp.Application.Constants
     public static class CustomClaimTypes
     {
         public const string Uid = "uid";
+        public const string BlogUserId = "blogUserId";
     }
 }

--- a/Backend/starter_project_dotnetforce7/BlogApp2/BlogApp.Application/Contracts/Persistence/IBlogRepository.cs
+++ b/Backend/starter_project_dotnetforce7/BlogApp2/BlogApp.Application/Contracts/Persistence/IBlogRepository.cs
@@ -11,5 +11,8 @@ namespace BlogApp.Application.Contracts.Persistence
     {
         Task<List<Blog>> GetBlogsWithRate();
 
+        Task<List<Blog>> GetBlogs();
+
+
     }
 }

--- a/Backend/starter_project_dotnetforce7/BlogApp2/BlogApp.Application/Features/Blog/CQRS/Handlers/GetBlogListQueryHandler.cs
+++ b/Backend/starter_project_dotnetforce7/BlogApp2/BlogApp.Application/Features/Blog/CQRS/Handlers/GetBlogListQueryHandler.cs
@@ -29,7 +29,7 @@ namespace BlogApp.Application.Features.Blogs.CQRS.Handlers
         {
 
             var response = new Result<List<BlogDto>>();
-            var Blogs = await _unitOfWork.BlogRepository.GetAll();
+            var Blogs = await _unitOfWork.BlogRepository.GetBlogs();
             
             response.Success = true;
             response.Message = "Fetch Success";

--- a/Backend/starter_project_dotnetforce7/BlogApp2/BlogApp.Application/Features/Blog/DTOs/BlogDto.cs
+++ b/Backend/starter_project_dotnetforce7/BlogApp2/BlogApp.Application/Features/Blog/DTOs/BlogDto.cs
@@ -17,7 +17,7 @@ namespace BlogApp.Application.Features.Blogs.DTOs
         public bool? PublicationStatus { get; set; }
 
         public ICollection<RateDto> Rates { get; set; }
-
+        public BlogUser Creator {get; set;}
         public double BlogRate { get; set; }
 
     }

--- a/Backend/starter_project_dotnetforce7/BlogApp2/BlogApp.Application/Features/Blog/DTOs/CreateBlogDto.cs
+++ b/Backend/starter_project_dotnetforce7/BlogApp2/BlogApp.Application/Features/Blog/DTOs/CreateBlogDto.cs
@@ -13,5 +13,6 @@ namespace BlogApp.Application.Features.Blogs.DTOs
         public string Content { get; set; }
         public string? CoverImage { get; set; }
         public bool? PublicationStatus { get; set; }
+        public string? CreatorId {get; set;}
     }
 }

--- a/Backend/starter_project_dotnetforce7/BlogApp2/BlogApp.Application/Features/Blog/DTOs/UpdateBlogDto.cs
+++ b/Backend/starter_project_dotnetforce7/BlogApp2/BlogApp.Application/Features/Blog/DTOs/UpdateBlogDto.cs
@@ -15,8 +15,8 @@ namespace BlogApp.Application.Features.Blogs.DTOs
         public string Content { get; set; }
         public string? CoverImage { get; set; }
         public bool? PublicationStatus { get; set; }
-
         public double BlogRate { get; set; }
+        
 
     }
 }

--- a/Backend/starter_project_dotnetforce7/BlogApp2/BlogApp.Application/Features/Tags/CQRS/Handlers/DeleteTagCommandHandler.cs
+++ b/Backend/starter_project_dotnetforce7/BlogApp2/BlogApp.Application/Features/Tags/CQRS/Handlers/DeleteTagCommandHandler.cs
@@ -27,7 +27,6 @@ namespace BlogApp.Application.Features.Tags.CQRS.Handlers
             var tag = await _unitOfWork.TagRepository.Get(request.Id);
 
             if (tag == null) {
-                Console.WriteLine(tag);
                 return null; }
                 
 

--- a/Backend/starter_project_dotnetforce7/BlogApp2/BlogApp.Application/Models/Identity/RegistrationResponse.cs
+++ b/Backend/starter_project_dotnetforce7/BlogApp2/BlogApp.Application/Models/Identity/RegistrationResponse.cs
@@ -4,4 +4,5 @@ namespace BlogApp.Application.Models.Identity;
 public class RegistrationResponse
 {
     public string UserId { get; set;}
+    public int blogUserId {get; set;}
 }  

--- a/Backend/starter_project_dotnetforce7/BlogApp2/BlogApp.Application/Models/Identity/User.cs
+++ b/Backend/starter_project_dotnetforce7/BlogApp2/BlogApp.Application/Models/Identity/User.cs
@@ -4,7 +4,9 @@ namespace BlogApp.Domain.Models.Identity
 {
     public class User
     {
-        public string Id { get; set; }
+        public int Id { get; set; }
+        public string AppUserId {get; set;}
+        public string Username {get; set;}
         public string Firstname { get; set; }
         public string Lastname { get; set; }
         public string Email { get; set; }

--- a/Backend/starter_project_dotnetforce7/BlogApp2/BlogApp.Application/Profiles/MappingProfile.cs
+++ b/Backend/starter_project_dotnetforce7/BlogApp2/BlogApp.Application/Profiles/MappingProfile.cs
@@ -25,6 +25,8 @@ namespace BlogApp.Application.Profiles
 
             CreateMap<Blog, BlogDto>()
             .ForMember(x => x.Rates, o => o.MapFrom(s => s.Rates))
+            .ForMember(x => x.Creator, o => o.MapFrom(s => s.Creator))
+
             .ForMember(x => x.BlogRate, o => o.MapFrom(s => s.Rates.Any() ? s.Rates.Average(r => r.RateNo) : 0));
 
             CreateMap<Blog, CreateBlogDto>().ReverseMap();

--- a/Backend/starter_project_dotnetforce7/BlogApp2/BlogApp.Domain/Blog.cs
+++ b/Backend/starter_project_dotnetforce7/BlogApp2/BlogApp.Domain/Blog.cs
@@ -9,7 +9,8 @@ namespace BlogApp.Domain
         public string Content { get; set; }
         public string? CoverImage { get; set; }
         public bool? PublicationStatus { get; set; }
-
+        public int CreatorId {get; set;}
+        public BlogUser Creator {get; set;}
         public ICollection<Rate> Rates { get; set; } // One-to-many relationship with Rate
 
     }

--- a/Backend/starter_project_dotnetforce7/BlogApp2/BlogApp.Domain/BlogUser.cs
+++ b/Backend/starter_project_dotnetforce7/BlogApp2/BlogApp.Domain/BlogUser.cs
@@ -1,0 +1,16 @@
+using BlogApp.Domain.Common;
+
+namespace BlogApp.Domain
+{
+    public class BlogUser : BaseDomainEntity
+    {
+        public string AppUserId {get; set;}
+        public string Firstname { get; set; }
+        public string Lastname { get; set; }
+        public string Username { get; set; }
+        public string Email { get; set; }
+        public string Role { get; set; }
+        // public ICollection<Blog> Blogs {get; set;}
+
+    }
+}

--- a/Backend/starter_project_dotnetforce7/BlogApp2/BlogApp.Identity.UnitTests/BlogApp.Identity.UnitTest.csproj
+++ b/Backend/starter_project_dotnetforce7/BlogApp2/BlogApp.Identity.UnitTests/BlogApp.Identity.UnitTest.csproj
@@ -31,5 +31,6 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\BlogApp.Identity\BlogApp.Identity.csproj" />
+    <ProjectReference Include="..\BlogApp.Persistence\BlogApp.Persistence.csproj" />
   </ItemGroup>
 </Project>

--- a/Backend/starter_project_dotnetforce7/BlogApp2/BlogApp.Identity.UnitTests/Services/UserServiceTests.cs
+++ b/Backend/starter_project_dotnetforce7/BlogApp2/BlogApp.Identity.UnitTests/Services/UserServiceTests.cs
@@ -54,7 +54,7 @@ namespace BlogApp.Identity.UnitTests
 
             // Assert
             Assert.NotNull(result);
-            Assert.Equal(userId, result.Id);
+            Assert.Equal(userId, result.AppUserId);
             Assert.Equal(user.Email, result.Email);
             Assert.Equal(user.Firstname, result.Firstname);
             Assert.Equal(user.Lastname, result.Lastname);
@@ -93,11 +93,11 @@ namespace BlogApp.Identity.UnitTests
             // Assert
             Assert.NotNull(result);
             Assert.Equal(users.Count, result.Count);
-            Assert.Equal(users[0].Id, result[0].Id);
+            Assert.Equal(users[0].Id, result[0].AppUserId);
             Assert.Equal(users[0].Email, result[0].Email);
             Assert.Equal(users[0].Firstname, result[0].Firstname);
             Assert.Equal(users[0].Lastname, result[0].Lastname);
-            Assert.Equal(users[1].Id, result[1].Id);
+            Assert.Equal(users[1].Id, result[1].AppUserId);
             Assert.Equal(users[1].Email, result[1].Email);
             Assert.Equal(users[1].Firstname, result[1].Firstname);
             Assert.Equal(users[1].Lastname, result[1].Lastname);

--- a/Backend/starter_project_dotnetforce7/BlogApp2/BlogApp.Identity/BlogApp.Identity.csproj
+++ b/Backend/starter_project_dotnetforce7/BlogApp2/BlogApp.Identity/BlogApp.Identity.csproj
@@ -37,5 +37,6 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\BlogApp.Application\BlogApp.Application.csproj" />
+    <ProjectReference Include="..\BlogApp.Persistence\BlogApp.Persistence.csproj" />
   </ItemGroup>
 </Project>

--- a/Backend/starter_project_dotnetforce7/BlogApp2/BlogApp.Identity/Configurations/UserRoleConfiguration.cs
+++ b/Backend/starter_project_dotnetforce7/BlogApp2/BlogApp.Identity/Configurations/UserRoleConfiguration.cs
@@ -13,12 +13,12 @@ namespace BlogApp.Identity.Configurations
                 new IdentityUserRole<string>
                 {
                     RoleId = "6123c2b5bf21e81f7ccf9385",
-                    UserId = "6123c291bf21e81f7ccf9384"
+                    UserId = "e6c52d57-24b6-4524-be10-eb7bce4d3217"
                 },
                 new IdentityUserRole<string>
                 {
                     RoleId = "6123c2c9bf21e81f7ccf9386",
-                    UserId = "6123c26ebf21e81f7ccf9383"
+                    UserId = "fb8656da-2b94-474f-8709-85e0cd7ea903"
                 }
             );
         }

--- a/Backend/starter_project_dotnetforce7/BlogApp2/BlogApp.Identity/Models/ApplicationUser.cs
+++ b/Backend/starter_project_dotnetforce7/BlogApp2/BlogApp.Identity/Models/ApplicationUser.cs
@@ -5,4 +5,5 @@ public class ApplicationUser : IdentityUser
 {
     public string Firstname { get; set; }
     public string Lastname { get; set; }
+    public int blogUserId {get; set;}
 }

--- a/Backend/starter_project_dotnetforce7/BlogApp2/BlogApp.Identity/Services/UserService.cs
+++ b/Backend/starter_project_dotnetforce7/BlogApp2/BlogApp.Identity/Services/UserService.cs
@@ -25,7 +25,7 @@ namespace BlogApp.Identity.Services
             return new User
             {
                 Email = user.Email,
-                Id = user.Id,
+                AppUserId = user.Id,
                 Firstname = user.Firstname,
                 Lastname = user.Lastname,
                 Roles = await _userManager.GetRolesAsync(user),
@@ -41,7 +41,7 @@ namespace BlogApp.Identity.Services
 
             return users.Select(q => new User
             {
-                Id = q.Id,
+                AppUserId = q.Id,
                 Email = q.Email,
                 Firstname = q.Firstname,
                 Lastname = q.Lastname

--- a/Backend/starter_project_dotnetforce7/BlogApp2/BlogApp.Persistence/BlogAppDbContext.cs
+++ b/Backend/starter_project_dotnetforce7/BlogApp2/BlogApp.Persistence/BlogAppDbContext.cs
@@ -48,6 +48,7 @@ namespace BlogApp.Persistence
         public DbSet<Blog> Blogs { get; set; }
 
         public DbSet<Comment> Comments { get; set; }
+        public DbSet<BlogUser> BlogUser {get; set;}
 
     }
 }

--- a/Backend/starter_project_dotnetforce7/BlogApp2/BlogApp.Persistence/BlogAppDbContextFactory.cs
+++ b/Backend/starter_project_dotnetforce7/BlogApp2/BlogApp.Persistence/BlogAppDbContextFactory.cs
@@ -15,7 +15,7 @@ namespace BlogApp.Persistence
         public BlogAppDbContext CreateDbContext(string[] args)
         {
             IConfigurationRoot configuration = new ConfigurationBuilder()
-                 .SetBasePath(Directory.GetCurrentDirectory())
+                 .SetBasePath(Directory.GetCurrentDirectory() + "/../BlogApp.API")
                  .AddJsonFile("appsettings.json")
                  .Build();
 

--- a/Backend/starter_project_dotnetforce7/BlogApp2/BlogApp.Persistence/Repositories/BlogRepository.cs
+++ b/Backend/starter_project_dotnetforce7/BlogApp2/BlogApp.Persistence/Repositories/BlogRepository.cs
@@ -26,8 +26,12 @@ namespace BlogApp.Persistence.Repositories
 
          public async Task<Blog> Get(int id)
         {
-            return await _dbContext.Set<Blog>().Include(x => x.Rates).FirstOrDefaultAsync(b => b.Id == id);
+            return await _dbContext.Set<Blog>().Include(x => x.Rates).Include(x => x.Creator).FirstOrDefaultAsync(b => b.Id == id);
         }
 
+        public async Task<List<Blog>> GetBlogs()
+        {
+            return await _dbContext.Set<Blog>().Include(x => x.Rates).Include(x => x.Creator).AsNoTracking().ToListAsync();
+        }
     }
 }


### PR DESCRIPTION
In this PR, we have created a different user model for the database context blogs and other models are using. This way, we're able to access users securely from both contexts.

We also added the relation user have with blog, and the other models could also be done the same way. 