### PR TITLE
feat(Mobile-Dartknights): Implement BLoC logic for Auth screens

### DIFF
--- a/Mobile/starter_project_dark_knights/lib/features/Authentication/presentation/bloc/authentication_bloc.dart
+++ b/Mobile/starter_project_dark_knights/lib/features/Authentication/presentation/bloc/authentication_bloc.dart
@@ -20,7 +20,7 @@ class AuthenticationBloc
   AuthenticationBloc({
     required this.loginUseCase,
     required this.signupUseCase,
-  }) : super(AuthenticationInitial()) {
+  }) : super(UnAuthenticated()) {
     on<LoginEvent>(_login);
     on<SignupEvent>(_signup);
   }
@@ -40,12 +40,12 @@ class AuthenticationBloc
   AuthenticationState _loginSuccessOrFailure(
       Either<Failure, Authentication> data) {
     return data.fold((failure) => AuthenticationFailure(error: failure),
-        (success) => AuthenticationSuccess(authentication: success));
+        (success) => Authenticated(authentication: success));
   }
 
   AuthenticationState _signupSuccessOrFailure(
       Either<Failure, Authentication> data) {
     return data.fold((failure) => AuthenticationFailure(error: failure),
-        (success) => AuthenticationSuccess(authentication: success));
+        (success) => Authenticated(authentication: success));
   }
 }

--- a/Mobile/starter_project_dark_knights/lib/features/Authentication/presentation/bloc/authentication_bloc.dart
+++ b/Mobile/starter_project_dark_knights/lib/features/Authentication/presentation/bloc/authentication_bloc.dart
@@ -20,7 +20,7 @@ class AuthenticationBloc
   AuthenticationBloc({
     required this.loginUseCase,
     required this.signupUseCase,
-  }) : super(UnAuthenticated()) {
+  }) : super(AuthenticationInitial()) {
     on<LoginEvent>(_login);
     on<SignupEvent>(_signup);
   }

--- a/Mobile/starter_project_dark_knights/lib/features/Authentication/presentation/bloc/authentication_bloc.dart
+++ b/Mobile/starter_project_dark_knights/lib/features/Authentication/presentation/bloc/authentication_bloc.dart
@@ -2,85 +2,50 @@ import 'package:bloc/bloc.dart';
 import 'package:dark_knights/core/errors/failures.dart';
 import 'package:dark_knights/features/Authentication/domain/entities/authentication_entitiy.dart';
 import 'package:dark_knights/features/Authentication/domain/repositories/authentication_repository.dart';
+import 'package:dark_knights/features/Authentication/domain/usecases/signupUsecase.dart';
 import 'package:dartz/dartz.dart';
 import 'package:equatable/equatable.dart';
 import 'package:flutter/material.dart';
+
+import '../../domain/usecases/loginUsecase.dart';
 
 part 'authentication_event.dart';
 part 'authentication_state.dart';
 
 class AuthenticationBloc
     extends Bloc<AuthenticationEvent, AuthenticationState> {
-  final AuthenticationRepository repository;
+  final LoginUseCase loginUseCase;
+  final SignupUseCase signupUseCase;
 
-  AuthenticationBloc({required this.repository})
-      : super(AuthenticationInitial()) {
-    on<LoginEvent>((event, emit) async {
-      emit(AuthenticationLoading());
-      final result = await repository.login(event.authCredentials);
-      if (result == Right(Failure)) {
-        emit(AuthenticationError(error: result));
-      } else {
-        emit(AuthenticationSuccess(authentication: result));
-      }
-    });
+  AuthenticationBloc({
+    required this.loginUseCase,
+    required this.signupUseCase,
+  }) : super(AuthenticationInitial()) {
+    on<LoginEvent>(_login);
+    on<SignupEvent>(_signup);
   }
 
-  @override
-  Stream<AuthenticationState> mapEventToState(
-    AuthenticationEvent event,
-  ) async* {
-    if (event is LoginEvent) {
-      yield AuthenticationLoading();
-      final result = await repository.login(event.authCredentials);
-      yield result.fold(
-        (failure) => AuthenticationError(message: failure.message),
-        (authentication) =>
-            AuthenticationSuccess(authentication: authentication),
-      );
-    } else if (event is SignupEvent) {
-      yield AuthenticationLoading();
-      final result = await repository.signup(event.newuser);
-      yield result.fold(
-        (failure) => AuthenticationError(message: failure.message),
-        (authentication) =>
-            AuthenticationSuccess(authentication: authentication),
-      );
-    }
+  void _login(LoginEvent event, Emitter<AuthenticationState> emit) async {
+    emit(AuthenticationLoading());
+    final result = await loginUseCase(event.authCredentials);
+    emit(_loginSuccessOrFailure(result));
+  }
+
+  void _signup(SignupEvent event, Emitter<AuthenticationState> emit) async {
+    emit(AuthenticationLoading());
+    final result = await signupUseCase(event.newAuthCredentials);
+    emit(_signupSuccessOrFailure(result));
+  }
+
+  AuthenticationState _loginSuccessOrFailure(
+      Either<Failure, Authentication> data) {
+    return data.fold((failure) => AuthenticationFailure(error: failure),
+        (success) => AuthenticationSuccess(authentication: success));
+  }
+
+  AuthenticationState _signupSuccessOrFailure(
+      Either<Failure, Authentication> data) {
+    return data.fold((failure) => AuthenticationFailure(error: failure),
+        (success) => AuthenticationSuccess(authentication: success));
   }
 }
-
-// import 'package:flutter_bloc/flutter_bloc.dart';
-// import 'package:frontend/repository/secure_storage.dart';
-// import 'package:frontend/blocs/auth/AuthEvent.dart';
-// import 'package:frontend/blocs/auth/AuthState.dart';
-
-// class AuthBloc extends Bloc<AuthEvent, AuthState> {
-//   final StorageService storage;
-//   AuthBloc(this.storage) : super(AuthInitital()) {
-//     on<CheckLogIn>((event, emit) async {
-//       final bool hasToken = await storage.hasToken();
-//       if (hasToken) {
-//         final String? token = await storage.getToken();
-//         final String? id = await storage.getId();
-//         final String? role = await storage.getRole();
-//         emit(Authenticated(role!, id!));
-//       }
-//     });
-//     on<LoggedIn>(
-//       (event, emit) async {
-//         emit(AuthLoading());
-//         print(event.role);
-//         await storage.saveIdAndToken(event.role!, event.id!, event.token!);
-//         emit(Authenticated(event.role!, event.id!));
-//       },
-//     );
-//     on<LogOut>(
-//       (event, emit) async {
-//         emit(AuthLoggingOut());
-//         await storage.deleteAll();
-//         emit(AuthInitital());
-//       },
-//     );
-//   }
-// }

--- a/Mobile/starter_project_dark_knights/lib/features/Authentication/presentation/bloc/authentication_bloc.dart
+++ b/Mobile/starter_project_dark_knights/lib/features/Authentication/presentation/bloc/authentication_bloc.dart
@@ -1,0 +1,86 @@
+import 'package:bloc/bloc.dart';
+import 'package:dark_knights/core/errors/failures.dart';
+import 'package:dark_knights/features/Authentication/domain/entities/authentication_entitiy.dart';
+import 'package:dark_knights/features/Authentication/domain/repositories/authentication_repository.dart';
+import 'package:dartz/dartz.dart';
+import 'package:equatable/equatable.dart';
+import 'package:flutter/material.dart';
+
+part 'authentication_event.dart';
+part 'authentication_state.dart';
+
+class AuthenticationBloc
+    extends Bloc<AuthenticationEvent, AuthenticationState> {
+  final AuthenticationRepository repository;
+
+  AuthenticationBloc({required this.repository})
+      : super(AuthenticationInitial()) {
+    on<LoginEvent>((event, emit) async {
+      emit(AuthenticationLoading());
+      final result = await repository.login(event.authCredentials);
+      if (result == Right(Failure)) {
+        emit(AuthenticationError(error: result));
+      } else {
+        emit(AuthenticationSuccess(authentication: result));
+      }
+    });
+  }
+
+  @override
+  Stream<AuthenticationState> mapEventToState(
+    AuthenticationEvent event,
+  ) async* {
+    if (event is LoginEvent) {
+      yield AuthenticationLoading();
+      final result = await repository.login(event.authCredentials);
+      yield result.fold(
+        (failure) => AuthenticationError(message: failure.message),
+        (authentication) =>
+            AuthenticationSuccess(authentication: authentication),
+      );
+    } else if (event is SignupEvent) {
+      yield AuthenticationLoading();
+      final result = await repository.signup(event.newuser);
+      yield result.fold(
+        (failure) => AuthenticationError(message: failure.message),
+        (authentication) =>
+            AuthenticationSuccess(authentication: authentication),
+      );
+    }
+  }
+}
+
+// import 'package:flutter_bloc/flutter_bloc.dart';
+// import 'package:frontend/repository/secure_storage.dart';
+// import 'package:frontend/blocs/auth/AuthEvent.dart';
+// import 'package:frontend/blocs/auth/AuthState.dart';
+
+// class AuthBloc extends Bloc<AuthEvent, AuthState> {
+//   final StorageService storage;
+//   AuthBloc(this.storage) : super(AuthInitital()) {
+//     on<CheckLogIn>((event, emit) async {
+//       final bool hasToken = await storage.hasToken();
+//       if (hasToken) {
+//         final String? token = await storage.getToken();
+//         final String? id = await storage.getId();
+//         final String? role = await storage.getRole();
+//         emit(Authenticated(role!, id!));
+//       }
+//     });
+//     on<LoggedIn>(
+//       (event, emit) async {
+//         emit(AuthLoading());
+//         print(event.role);
+//         await storage.saveIdAndToken(event.role!, event.id!, event.token!);
+//         emit(Authenticated(event.role!, event.id!));
+//       },
+//     );
+//     on<LogOut>(
+//       (event, emit) async {
+//         emit(AuthLoggingOut());
+//         await storage.deleteAll();
+//         emit(AuthInitital());
+//       },
+//     );
+//   }
+// }

--- a/Mobile/starter_project_dark_knights/lib/features/Authentication/presentation/bloc/authentication_event.dart
+++ b/Mobile/starter_project_dark_knights/lib/features/Authentication/presentation/bloc/authentication_event.dart
@@ -1,0 +1,26 @@
+part of 'authentication_bloc.dart';
+
+abstract class AuthenticationEvent extends Equatable {
+  const AuthenticationEvent();
+
+  @override
+  List<Object> get props => [];
+}
+
+class LoginEvent extends AuthenticationEvent {
+  final Authentication authCredentials;
+
+  const LoginEvent({required this.authCredentials});
+
+  @override
+  List<Object> get props => [authCredentials];
+}
+
+class SignupEvent extends AuthenticationEvent {
+  final Authentication newAuthCredentials;
+
+  const SignupEvent({required this.newAuthCredentials});
+
+  @override
+  List<Object> get props => [newAuthCredentials];
+}

--- a/Mobile/starter_project_dark_knights/lib/features/Authentication/presentation/bloc/authentication_state.dart
+++ b/Mobile/starter_project_dark_knights/lib/features/Authentication/presentation/bloc/authentication_state.dart
@@ -7,14 +7,14 @@ abstract class AuthenticationState extends Equatable {
   List<Object> get props => [];
 }
 
-class AuthenticationInitial extends AuthenticationState {}
+class UnAuthenticated extends AuthenticationState {}
 
 class AuthenticationLoading extends AuthenticationState {}
 
-class AuthenticationSuccess extends AuthenticationState {
+class Authenticated extends AuthenticationState {
   final Authentication authentication;
 
-  const AuthenticationSuccess({required this.authentication});
+  const Authenticated({required this.authentication});
 
   @override
   List<Object> get props => [authentication];

--- a/Mobile/starter_project_dark_knights/lib/features/Authentication/presentation/bloc/authentication_state.dart
+++ b/Mobile/starter_project_dark_knights/lib/features/Authentication/presentation/bloc/authentication_state.dart
@@ -7,7 +7,7 @@ abstract class AuthenticationState extends Equatable {
   List<Object> get props => [];
 }
 
-class UnAuthenticated extends AuthenticationState {}
+class AuthenticationInitial extends AuthenticationState {}
 
 class AuthenticationLoading extends AuthenticationState {}
 

--- a/Mobile/starter_project_dark_knights/lib/features/Authentication/presentation/bloc/authentication_state.dart
+++ b/Mobile/starter_project_dark_knights/lib/features/Authentication/presentation/bloc/authentication_state.dart
@@ -1,0 +1,30 @@
+part of 'authentication_bloc.dart';
+
+abstract class AuthenticationState extends Equatable {
+  const AuthenticationState();
+
+  @override
+  List<Object> get props => [];
+}
+
+class AuthenticationInitial extends AuthenticationState {}
+
+class AuthenticationLoading extends AuthenticationState {}
+
+class AuthenticationSuccess extends AuthenticationState {
+  final Authentication authentication;
+
+  const AuthenticationSuccess({required this.authentication});
+
+  @override
+  List<Object> get props => [authentication];
+}
+
+class AuthenticationError extends AuthenticationState {
+  final Failure error;
+
+  const AuthenticationError({required this.error});
+
+  @override
+  List<Object> get props => [message];
+}

--- a/Mobile/starter_project_dark_knights/lib/features/Authentication/presentation/bloc/authentication_state.dart
+++ b/Mobile/starter_project_dark_knights/lib/features/Authentication/presentation/bloc/authentication_state.dart
@@ -20,11 +20,11 @@ class AuthenticationSuccess extends AuthenticationState {
   List<Object> get props => [authentication];
 }
 
-class AuthenticationError extends AuthenticationState {
+class AuthenticationFailure extends AuthenticationState {
   final Failure error;
 
-  const AuthenticationError({required this.error});
+  const AuthenticationFailure({required this.error});
 
   @override
-  List<Object> get props => [message];
+  List<Object> get props => [error];
 }

--- a/Mobile/starter_project_dark_knights/pubspec.yaml
+++ b/Mobile/starter_project_dark_knights/pubspec.yaml
@@ -42,6 +42,7 @@ dependencies:
   internet_connection_checker: ^1.0.0+1
   http: ^0.13.6
   shared_preferences: ^2.1.1
+  flutter_bloc: ^8.1.2
   
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Team: Mobile
TeamName: Dartknights
Task Name: Implement bloc logic for Auth screens
Task Description: Implement BLoC logic for Auth screens (Login and sign up screens). This task should only focus on the implementation of the bloc logic. We should use generative Ai tools to guide through the implementation. Test and the consumption of the bloc are not expected to be implemented in this task.